### PR TITLE
Add basic FontConfig implementation

### DIFF
--- a/FontAtlas.go
+++ b/FontAtlas.go
@@ -74,6 +74,12 @@ func (atlas FontAtlas) AddFontDefault() Font {
 	return Font(fontHandle)
 }
 
+// AddFontDefaultV adds the default font to the atlas using the specified FontConfig.
+func (atlas FontAtlas) AddFontDefaultV(cfg FontConfig) Font {
+	fontHandle := C.iggAddFontDefaultV(atlas.handle(), cfg.handle())
+	return Font(fontHandle)
+}
+
 // AddFontFromFileTTFV attempts to load a font from given TTF file.
 func (atlas FontAtlas) AddFontFromFileTTFV(filename string, sizePixels float32,
 	config FontConfig, glyphRange GlyphRanges) Font {

--- a/FontAtlasWrapper.cpp
+++ b/FontAtlasWrapper.cpp
@@ -51,6 +51,14 @@ IggFont iggAddFontDefault(IggFontAtlas handle)
    return static_cast<IggFont>(font);
 }
 
+IggFont iggAddFontDefaultV(IggFontAtlas handle, IggFontConfig config)
+{
+   ImFontAtlas *fontAtlas = reinterpret_cast<ImFontAtlas *>(handle);
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(config);
+   ImFont *font = fontAtlas->AddFontDefault(fontConfig);
+   return static_cast<IggFont>(font);  
+}
+
 IggFont iggAddFontFromFileTTF(IggFontAtlas handle, char const *filename, float sizePixels,
       IggFontConfig config, IggGlyphRanges glyphRanges)
 {

--- a/FontAtlasWrapper.h
+++ b/FontAtlasWrapper.h
@@ -16,6 +16,7 @@ extern IggGlyphRanges iggGetGlyphRangesCyrillic(IggFontAtlas handle);
 extern IggGlyphRanges iggGetGlyphRangesThai(IggFontAtlas handle);
 
 extern IggFont iggAddFontDefault(IggFontAtlas handle);
+extern IggFont iggAddFontDefaultV(IggFontAtlas handle, IggFontConfig config);
 extern IggFont iggAddFontFromFileTTF(IggFontAtlas handle, char const *filename, float sizePixels,
 		IggFontConfig config, IggGlyphRanges glyphRanges);
 

--- a/FontConfig.go
+++ b/FontConfig.go
@@ -1,14 +1,91 @@
 package imgui
 
-// #include "imguiWrapperTypes.h"
+// #include "FontConfigWrapper.h"
 import "C"
 
 // FontConfig describes properties of a single font.
 type FontConfig uintptr
 
 // DefaultFontConfig lets ImGui take default properties as per implementation.
+// The properties of the default configuration cannot be changed using the SetXXX functions.
 const DefaultFontConfig FontConfig = 0
 
 func (config FontConfig) handle() C.IggFontConfig {
 	return C.IggFontConfig(config)
+}
+
+// NewFontConfig creates a new font configuration.
+// Delete must be called on the returned config.
+func NewFontConfig() FontConfig {
+	configHandle := C.iggNewFontConfig()
+	return FontConfig(configHandle)
+}
+
+// Delete removes the font configuration and resets it to the DefaultFontConfig.
+func (config *FontConfig) Delete() {
+	if *config != DefaultFontConfig {
+		C.iggFontConfigDelete(config.handle())
+		*config = DefaultFontConfig
+	}
+}
+
+// SetSize sets the size in pixels for rasterizer (more or less maps to the
+// resulting font height).
+func (config FontConfig) SetSize(sizePixels float32) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetSize(config.handle(), C.float(sizePixels))
+	}
+}
+
+// SetOversampleH sets the oversampling amount for the X axis.
+// Rasterize at higher quality for sub-pixel positioning.
+// We don't use sub-pixel positions on the Y axis.
+func (config FontConfig) SetOversampleH(value int) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetOversampleH(config.handle(), C.int(value))
+	}
+}
+
+// SetOversampleV sets the oversampling amount for the Y axis.
+// Rasterize at higher quality for sub-pixel positioning.
+// We don't use sub-pixel positions on the Y axis.
+func (config FontConfig) SetOversampleV(value int) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetOversampleV(config.handle(), C.int(value))
+	}
+}
+
+// SetPixelSnapH aligns every glyph to pixel boundary if enabled. Useful e.g. if
+// you are merging a non-pixel aligned font with the default font. If enabled,
+// you can set OversampleH/V to 1.
+func (config FontConfig) SetPixelSnapH(value bool) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetPixelSnapH(config.handle(), castBool(value))
+	}
+}
+
+// SetGlyphMinAdvanceX sets the minimum AdvanceX for glyphs.
+// Set Min to align font icons, set both Min/Max to enforce mono-space font.
+func (config FontConfig) SetGlyphMinAdvanceX(value float32) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetGlyphMinAdvanceX(config.handle(), C.float(value))
+	}
+}
+
+// SetGlyphMaxAdvanceX sets the maximum AdvanceX for glyphs.
+// Set both Min/Max to enforce mono-space font.
+func (config FontConfig) SetGlyphMaxAdvanceX(value float32) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetGlyphMaxAdvanceX(config.handle(), C.float(value))
+	}
+}
+
+// SetMergeMode merges the new fonts into the previous font if enabled. This way
+// you can combine multiple input fonts into one (e.g. ASCII font + icons +
+// Japanese glyphs). You may want to use GlyphOffset.y when merge font of
+// different heights.
+func (config FontConfig) SetMergeMode(value bool) {
+	if config != DefaultFontConfig {
+		C.iggFontConfigSetMergeMode(config.handle(), castBool(value))
+	}
 }

--- a/FontConfigWrapper.cpp
+++ b/FontConfigWrapper.cpp
@@ -1,0 +1,56 @@
+#include "imguiWrappedHeader.h"
+#include "FontConfigWrapper.h"
+
+IggFontConfig iggNewFontConfig()
+{
+   ImFontConfig *fontConfig = new ImFontConfig();
+   return static_cast<IggFontConfig>(fontConfig);
+}
+
+void iggFontConfigDelete(IggFontConfig handle)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   delete fontConfig;
+}
+
+void iggFontConfigSetSize(IggFontConfig handle, float sizePixels)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->SizePixels = sizePixels;
+}
+
+void iggFontConfigSetOversampleH(IggFontConfig handle, int value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->OversampleH = value;
+}
+
+void iggFontConfigSetOversampleV(IggFontConfig handle, int value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->OversampleV = value;
+}
+
+void iggFontConfigSetPixelSnapH(IggFontConfig handle, IggBool value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->PixelSnapH = value;
+}
+
+void iggFontConfigSetGlyphMinAdvanceX(IggFontConfig handle, float value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->GlyphMinAdvanceX = value;
+}
+
+void iggFontConfigSetGlyphMaxAdvanceX(IggFontConfig handle, float value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->GlyphMaxAdvanceX = value;
+}
+
+void iggFontConfigSetMergeMode(IggFontConfig handle, IggBool value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   fontConfig->MergeMode = value;
+}

--- a/FontConfigWrapper.h
+++ b/FontConfigWrapper.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "imguiWrapperTypes.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+extern IggFontConfig iggNewFontConfig();
+extern void iggFontConfigDelete(IggFontConfig handle);
+
+extern void iggFontConfigSetSize(IggFontConfig handle, float sizePixels);
+extern void iggFontConfigSetOversampleH(IggFontConfig handle, int value);
+extern void iggFontConfigSetOversampleV(IggFontConfig handle, int value);
+extern void iggFontConfigSetPixelSnapH(IggFontConfig handle, IggBool value);
+extern void iggFontConfigSetGlyphMinAdvanceX(IggFontConfig handle, float value);
+extern void iggFontConfigSetGlyphMaxAdvanceX(IggFontConfig handle, float value);
+extern void iggFontConfigSetMergeMode(IggFontConfig handle, IggBool value);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Adds functions to create and delete FontConfig objects and set basic properties.

The `(cfg *FontConfig) Delete` function resets the `FontConfig` handle to 0 / `nullptr` / the default configuration after deleting the C object and the other functions check the passed handle to avoid double-frees and null dereferences.

(For previous discussion see #26)