### PR TITLE
Add simple math operations to vector types

### DIFF
--- a/Vectors.go
+++ b/Vectors.go
@@ -9,6 +9,30 @@ type Vec2 struct {
 	Y float32
 }
 
+// Plus returns vec + other.
+func (vec Vec2) Plus(other Vec2) Vec2 {
+	return Vec2{
+		X: vec.X + other.X,
+		Y: vec.Y + other.Y,
+	}
+}
+
+// Minus returns vec - other.
+func (vec Vec2) Minus(other Vec2) Vec2 {
+	return Vec2{
+		X: vec.X - other.X,
+		Y: vec.Y - other.Y,
+	}
+}
+
+// Times returns vec * value.
+func (vec Vec2) Times(value float32) Vec2 {
+	return Vec2{
+		X: vec.X * value,
+		Y: vec.Y * value,
+	}
+}
+
 func (vec *Vec2) wrapped() (out *C.IggVec2, finisher func()) {
 	if vec != nil {
 		out = &C.IggVec2{
@@ -51,4 +75,34 @@ func (vec *Vec4) wrapped() (out *C.IggVec4, finisher func()) {
 		finisher = func() {}
 	}
 	return
+}
+
+// Plus returns vec + other.
+func (vec Vec4) Plus(other Vec4) Vec4 {
+	return Vec4{
+		X: vec.X + other.X,
+		Y: vec.Y + other.Y,
+		Z: vec.Z + other.Z,
+		W: vec.W + other.W,
+	}
+}
+
+// Minus returns vec - other.
+func (vec Vec4) Minus(other Vec4) Vec4 {
+	return Vec4{
+		X: vec.X - other.X,
+		Y: vec.Y - other.Y,
+		Z: vec.Z - other.Z,
+		W: vec.W - other.W,
+	}
+}
+
+// Times returns vec * value.
+func (vec Vec4) Times(value float32) Vec4 {
+	return Vec4{
+		X: vec.X * value,
+		Y: vec.Y * value,
+		Z: vec.Z * value,
+		W: vec.W * value,
+	}
 }


### PR DESCRIPTION
For example this:

```
cursor := imgui.CursorScreenPos()
padding := style.FramePadding()
x, y := cursor.X + padding.X, cursor.Y + padding.Y
w, h := size.X - 2 * padding.X, size.Y - 2 * padding.Y

drawList.AddRectFilled(cursor, imgui.Vec2{X:cursor.X + size.X, Y:cursor.Y+size.Y}, 0xff800000)
drawList.AddLine(imgui.Vec2{X: x, Y: y}, imgui.Vec2{X: x+ w, Y: y +h}, 0xff00ff88)
```

turns into this:

```
cursor := imgui.CursorScreenPos()
padding := style.FramePadding()
start := cursor.Plus(padding)
innerSize := size.Minus(padding.Times(2))

drawList.AddRectFilled(cursor, cursor.Plus(size), 0xff800000)
drawList.AddLine(start, start.Plus(innerSize), 0xff00ff88)
```

Works nicely with inline getters and setters as well:

```
imgui.SetCursorPos(imgui.CursorPos().Plus(imgui.Vec2{Y: padY}))
```