### PR TITLE
Expose AddFontFromMemoryTTF

### DIFF
--- a/FontAtlasWrapper.cpp
+++ b/FontAtlasWrapper.cpp
@@ -69,6 +69,17 @@ IggFont iggAddFontFromFileTTF(IggFontAtlas handle, char const *filename, float s
    return static_cast<IggFont>(font);
 }
 
+IggFont iggAddFontFromMemoryTTF(IggFontAtlas handle, char *font_data, int font_size, float sizePixels,
+      IggFontConfig config, IggGlyphRanges glyphRanges)
+{
+   ImFontAtlas *fontAtlas = reinterpret_cast<ImFontAtlas *>(handle);
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(config);
+   ImWchar *glyphChars = reinterpret_cast<ImWchar *>(glyphRanges);
+   ImFont *font = fontAtlas->AddFontFromMemoryTTF(font_data, font_size, sizePixels, fontConfig, glyphChars);
+   return static_cast<IggFont>(font);
+}
+
+
 void iggFontAtlasSetTexDesiredWidth(IggFontAtlas handle, int value)
 {
    ImFontAtlas *fontAtlas = reinterpret_cast<ImFontAtlas *>(handle);

--- a/FontAtlasWrapper.h
+++ b/FontAtlasWrapper.h
@@ -19,6 +19,9 @@ extern IggFont iggAddFontDefault(IggFontAtlas handle);
 extern IggFont iggAddFontDefaultV(IggFontAtlas handle, IggFontConfig config);
 extern IggFont iggAddFontFromFileTTF(IggFontAtlas handle, char const *filename, float sizePixels,
 		IggFontConfig config, IggGlyphRanges glyphRanges);
+extern IggFont iggAddFontFromMemoryTTF(IggFontAtlas handle, char *font_data, int font_size, float sizePixels,
+		IggFontConfig config, IggGlyphRanges glyphRanges);
+
 
 extern void iggFontAtlasSetTexDesiredWidth(IggFontAtlas handle, int value);
 

--- a/FontConfig.go
+++ b/FontConfig.go
@@ -89,3 +89,12 @@ func (config FontConfig) SetMergeMode(value bool) {
 		C.iggFontConfigSetMergeMode(config.handle(), castBool(value))
 	}
 }
+
+// getFontDataOwnedByAtlas gets the current ownership status of the font data.
+func (config FontConfig) getFontDataOwnedByAtlas() bool {
+	if config != DefaultFontConfig {
+		return C.iggFontConfigGetFontDataOwnedByAtlas(config.handle()) != 0
+	}
+
+	return true
+}

--- a/FontConfigWrapper.cpp
+++ b/FontConfigWrapper.cpp
@@ -54,3 +54,9 @@ void iggFontConfigSetMergeMode(IggFontConfig handle, IggBool value)
    ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
    fontConfig->MergeMode = value;
 }
+
+int iggFontConfigGetFontDataOwnedByAtlas(IggFontConfig handle)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   return fontConfig->FontDataOwnedByAtlas;
+}

--- a/FontConfigWrapper.h
+++ b/FontConfigWrapper.h
@@ -17,6 +17,7 @@ extern void iggFontConfigSetPixelSnapH(IggFontConfig handle, IggBool value);
 extern void iggFontConfigSetGlyphMinAdvanceX(IggFontConfig handle, float value);
 extern void iggFontConfigSetGlyphMaxAdvanceX(IggFontConfig handle, float value);
 extern void iggFontConfigSetMergeMode(IggFontConfig handle, IggBool value);
+extern int iggFontConfigGetFontDataOwnedByAtlas(IggFontConfig handle);
 
 #ifdef __cplusplus
 }

--- a/WindowFlags.go
+++ b/WindowFlags.go
@@ -16,6 +16,8 @@ const (
 	WindowFlagsNoCollapse = 1 << 5
 	// WindowFlagsAlwaysAutoResize resizes every window to its content every frame.
 	WindowFlagsAlwaysAutoResize = 1 << 6
+	// WindowFlagsNoBackground disables drawing background color (WindowBg, etc.) and outside border.
+	WindowFlagsNoBackground = 1 << 7
 	// WindowFlagsNoSavedSettings prohibits load/save settings in .ini file.
 	WindowFlagsNoSavedSettings = 1 << 8
 	// WindowFlagsNoInputs disables catching mouse or keyboard inputs, hovering test with pass through.


### PR DESCRIPTION
This PR "depends" on #55.

This PR exposes the `AddFontFromMemoryTTF` function in the Go API. This allows loading of fonts from memory.
