### PR TITLE
More functions including Drawlist primitives

### DIFF
--- a/DrawList.go
+++ b/DrawList.go
@@ -158,3 +158,26 @@ func (list DrawList) AddCircleV(center Vec2, radius float32, col uint32, numSegm
 	centerArg, _ := center.wrapped()
 	C.iggAddCircle(list.handle(), centerArg, C.float(radius), C.ImU32(col), C.int(numSegments), C.float(thickness))
 }
+
+// AddTriangle calls addTriangleV with a thickness of 1.0
+func (list DrawList) AddTriangle(p1 Vec2, p2 Vec2, p3 Vec2, col uint32) {
+	list.AddTriangleV(p1, p2, p3, col, 1.0)
+}
+
+// AddTriangleV adds an unfilled triangle of points p1, p2, p3 to the draw
+// list.
+func (list DrawList) AddTriangleV(p1 Vec2, p2 Vec2, p3 Vec2, col uint32, thickness float32) {
+	p1Arg, _ := p1.wrapped()
+	p2Arg, _ := p2.wrapped()
+	p3Arg, _ := p3.wrapped()
+	C.iggAddTriangle(list.handle(), p1Arg, p2Arg, p3Arg, C.ImU32(col), C.float(thickness))
+}
+
+// AddTriangleFilled adds an filled triangle of points p1, p2, p3 to the draw
+// list.
+func (list DrawList) AddTriangleFilled(p1 Vec2, p2 Vec2, p3 Vec2, col uint32) {
+	p1Arg, _ := p1.wrapped()
+	p2Arg, _ := p2.wrapped()
+	p3Arg, _ := p3.wrapped()
+	C.iggAddTriangleFilled(list.handle(), p1Arg, p2Arg, p3Arg, C.ImU32(col))
+}

--- a/DrawList.go
+++ b/DrawList.go
@@ -142,8 +142,19 @@ func (list DrawList) AddCircleFilled(center Vec2, radius float32, col uint32) {
 
 // AddCircleFilledV adds a filled circle to the draw list. min is the
 // upper-left corner of the rectangle, and max is the lower right corner.
-// rectangles with dimensions of 1 pixel are not rendererd properly.
 func (list DrawList) AddCircleFilledV(center Vec2, radius float32, col uint32, numSegments int) {
 	centerArg, _ := center.wrapped()
 	C.iggAddCircleFilled(list.handle(), centerArg, C.float(radius), C.ImU32(col), C.int(numSegments))
+}
+
+// AddCircle calls addCircleV with a numSegments value of 12
+func (list DrawList) AddCircle(center Vec2, radius float32, col uint32) {
+	list.AddCircleV(center, radius, col, 12, 1.0)
+}
+
+// AddCircleV adds a unfilled circle to the draw list. min is the upper-left
+// corner of the rectangle, and max is the lower right corner.
+func (list DrawList) AddCircleV(center Vec2, radius float32, col uint32, numSegments int, thickness float32) {
+	centerArg, _ := center.wrapped()
+	C.iggAddCircle(list.handle(), centerArg, C.float(radius), C.ImU32(col), C.int(numSegments), C.float(thickness))
 }

--- a/DrawList.go
+++ b/DrawList.go
@@ -83,3 +83,67 @@ func (list DrawList) IndexBuffer() (unsafe.Pointer, int) {
 
 	return data, int(size)
 }
+
+// WindowDrawList returns the DrawList for the current window.
+func WindowDrawList() DrawList {
+	return DrawList(C.iggGetWindowDrawList())
+}
+
+// List of DrawCornerFlags
+const (
+	DrawCornerFlagsNone = 0 << iota
+	DrawCornerFlagsTopLeft
+	DrawCornerFlagsTopRight
+	DrawCornerFlagsBotLeft
+	DrawCornerFlagsBotRight
+	DrawCornerFlagsTop   = DrawCornerFlagsTopLeft | DrawCornerFlagsTopRight
+	DrawCornerFlagsBot   = DrawCornerFlagsBotLeft | DrawCornerFlagsBotRight
+	DrawCornerFlagsLeft  = DrawCornerFlagsTopLeft | DrawCornerFlagsBotLeft
+	DrawCornerFlagsRight = DrawCornerFlagsTopRight | DrawCornerFlagsBotRight
+	DrawCornerFlagsAll   = 0x0f
+)
+
+// AddRect calls AddRectV with rounding and thickness values of 1.0 and
+// DrawCornerFlagsAll
+func (list DrawList) AddRect(min Vec2, max Vec2, col uint32) {
+	list.AddRectV(min, max, col, 1.0, DrawCornerFlagsAll, 1.0)
+}
+
+// AddRectV adds a rectangle to draw list. min is the upper-left corner of the
+// rectangle, and max is the lower right corner. rectangles with dimensions of
+// 1 pixel are not rendererd properly.
+//
+// drawCornerFlags indicate which corners of the rectanble are to be rounded.
+func (list DrawList) AddRectV(min Vec2, max Vec2, col uint32, rounding float32, drawCornerFlags int, thickness float32) {
+	minArg, _ := min.wrapped()
+	maxArg, _ := max.wrapped()
+	C.iggAddRect(list.handle(), minArg, maxArg, C.ImU32(col), C.float(rounding), C.int(drawCornerFlags), C.float(thickness))
+}
+
+// AddRectFilled calls AddRectFilledV with a radius value of 1.0 and
+// DrawCornerFlagsAll
+func (list DrawList) AddRectFilled(min Vec2, max Vec2, col uint32) {
+	list.AddRectFilledV(min, max, col, 1.0, DrawCornerFlagsAll)
+}
+
+// AddRectFilledV adds a filled rectangle to the draw list. min is the
+// upper-left corner of the rectangle, and max is the lower right corner.
+// rectangles with dimensions of 1 pixel are not rendererd properly.
+func (list DrawList) AddRectFilledV(min Vec2, max Vec2, col uint32, rounding float32, drawCornerFlags int) {
+	minArg, _ := min.wrapped()
+	maxArg, _ := max.wrapped()
+	C.iggAddRectFilled(list.handle(), minArg, maxArg, C.ImU32(col), C.float(rounding), C.int(drawCornerFlags))
+}
+
+// AddCircleFilled calls addCircleFilledV with a numSegments value of 12
+func (list DrawList) AddCircleFilled(center Vec2, radius float32, col uint32) {
+	list.AddCircleFilledV(center, radius, col, 12)
+}
+
+// AddCircleFilledV adds a filled circle to the draw list. min is the
+// upper-left corner of the rectangle, and max is the lower right corner.
+// rectangles with dimensions of 1 pixel are not rendererd properly.
+func (list DrawList) AddCircleFilledV(center Vec2, radius float32, col uint32, numSegments int) {
+	centerArg, _ := center.wrapped()
+	C.iggAddCircleFilled(list.handle(), centerArg, C.float(radius), C.ImU32(col), C.int(numSegments))
+}

--- a/DrawListWrapper.cpp
+++ b/DrawListWrapper.cpp
@@ -59,6 +59,14 @@ void iggAddRectFilled(IggDrawList handle, IggVec2 const *min, IggVec2 const *max
    list->AddRectFilled(*minArg, *maxArg, col, rounding, flags);
 }
 
+void iggAddCircle(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments, float thickness)
+{
+   Vec2Wrapper centerArg(center);
+
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->AddCircle(*centerArg, radius, col, numSegments, thickness);
+}
+
 void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments)
 {
    Vec2Wrapper centerArg(center);

--- a/DrawListWrapper.cpp
+++ b/DrawListWrapper.cpp
@@ -75,6 +75,24 @@ void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius,
    list->AddCircleFilled(*centerArg, radius, col, numSegments);
 }
 
+void iggAddTriangle(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 *p3, ImU32 col, float thickness) {
+   Vec2Wrapper p1Arg(p1);
+   Vec2Wrapper p2Arg(p2);
+   Vec2Wrapper p3Arg(p3);
+
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->AddTriangle(*p1Arg, *p2Arg, *p3Arg, col, thickness);
+}
+
+void iggAddTriangleFilled(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 *p3, ImU32 col) {
+   Vec2Wrapper p1Arg(p1);
+   Vec2Wrapper p2Arg(p2);
+   Vec2Wrapper p3Arg(p3);
+
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->AddTriangleFilled(*p1Arg, *p2Arg, *p3Arg, col);
+}
+
 IggDrawList iggGetWindowDrawList() {
    return static_cast<IggDrawList>(const_cast<ImDrawList *>(ImGui::GetWindowDrawList()));
 }

--- a/DrawListWrapper.cpp
+++ b/DrawListWrapper.cpp
@@ -40,3 +40,33 @@ void iggGetVertexBufferLayout(size_t *entrySize, size_t *posOffset, size_t *uvOf
    *uvOffset = IM_OFFSETOF(ImDrawVert, uv);
    *colOffset = IM_OFFSETOF(ImDrawVert, col);
 }
+
+void iggAddRect(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags, float thickness)
+{
+   Vec2Wrapper minArg(min);
+   Vec2Wrapper maxArg(max);
+
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->AddRect(*minArg, *maxArg, col, rounding, flags, thickness);
+}
+
+void iggAddRectFilled(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags)
+{
+   Vec2Wrapper minArg(min);
+   Vec2Wrapper maxArg(max);
+
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->AddRectFilled(*minArg, *maxArg, col, rounding, flags);
+}
+
+void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments)
+{
+   Vec2Wrapper centerArg(center);
+
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->AddCircleFilled(*centerArg, radius, col, numSegments);
+}
+
+IggDrawList iggGetWindowDrawList() {
+   return static_cast<IggDrawList>(const_cast<ImDrawList *>(ImGui::GetWindowDrawList()));
+}

--- a/DrawListWrapper.h
+++ b/DrawListWrapper.h
@@ -17,6 +17,7 @@ extern void iggGetVertexBufferLayout(size_t *entrySize, size_t *posOffset, size_
 
 extern void iggAddRect(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags, float thickness);
 extern void iggAddRectFilled(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags);
+extern void iggAddCircle(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments, float thickness);
 extern void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments);
 
 extern IggDrawList iggGetWindowDrawList();

--- a/DrawListWrapper.h
+++ b/DrawListWrapper.h
@@ -15,6 +15,12 @@ extern void iggDrawListGetRawVertexBuffer(IggDrawList handle, void **data, int *
 extern void iggGetIndexBufferLayout(size_t *entrySize);
 extern void iggGetVertexBufferLayout(size_t *entrySize, size_t *posOffset, size_t *uvOffset, size_t *colOffset);
 
+extern void iggAddRect(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags, float thickness);
+extern void iggAddRectFilled(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags);
+extern void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments);
+
+extern IggDrawList iggGetWindowDrawList();
+
 #ifdef __cplusplus
 }
 #endif

--- a/DrawListWrapper.h
+++ b/DrawListWrapper.h
@@ -19,6 +19,8 @@ extern void iggAddRect(IggDrawList handle, IggVec2 const *min, IggVec2 const *ma
 extern void iggAddRectFilled(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, ImU32 col, float rounding, int flags);
 extern void iggAddCircle(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments, float thickness);
 extern void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius, ImU32 col, int numSegments);
+extern void iggAddTriangle(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 *p3, ImU32 col, float thickness);
+extern void iggAddTriangleFilled(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 *p3, ImU32 col);
 
 extern IggDrawList iggGetWindowDrawList();
 

--- a/Style.go
+++ b/Style.go
@@ -127,6 +127,15 @@ func (style Style) ItemInnerSpacing() Vec2 {
 	return value
 }
 
+// FramePadding is the padding within a framed rectangle (used by most widgets)
+func (style Style) FramePadding() Vec2 {
+	var value Vec2
+	valueArg, valueFin := value.wrapped()
+	C.iggStyleGetFramePadding(style.handle(), valueArg)
+	valueFin()
+	return value
+}
+
 // SetColor sets a color value of the UI style.
 func (style Style) SetColor(id StyleColorID, value Vec4) {
 	valueArg, _ := value.wrapped()

--- a/StyleWrapper.cpp
+++ b/StyleWrapper.cpp
@@ -8,6 +8,12 @@ void iggStyleGetItemInnerSpacing(IggGuiStyle handle, IggVec2 *value)
    exportValue(*value, style->ItemInnerSpacing);
 }
 
+void iggStyleGetFramePadding(IggGuiStyle handle, IggVec2 *value)
+{
+   ImGuiStyle *style = reinterpret_cast<ImGuiStyle *>(handle);
+   exportValue(*value, style->FramePadding);
+}
+
 void iggStyleSetColor(IggGuiStyle handle, int colorID, IggVec4 const *value)
 {
    ImGuiStyle *style = reinterpret_cast<ImGuiStyle *>(handle);

--- a/StyleWrapper.h
+++ b/StyleWrapper.h
@@ -9,6 +9,8 @@ extern "C"
 
 extern void iggStyleGetItemInnerSpacing(IggGuiStyle handle, IggVec2 *value);
 
+extern void iggStyleGetFramePadding(IggGuiStyle handle, IggVec2 *value);
+
 extern void iggStyleSetColor(IggGuiStyle handle, int index, IggVec4 const *color);
 
 extern void iggStyleScaleAllSizes(IggGuiStyle handle, float scale);

--- a/imgui.go
+++ b/imgui.go
@@ -330,6 +330,19 @@ func Button(id string) bool {
 	return ButtonV(id, Vec2{})
 }
 
+// InvisibleButtonV returning true if it is pressed.
+func InvisibleButtonV(id string, size Vec2) bool {
+	idArg, idFin := wrapString(id)
+	defer idFin()
+	sizeArg, _ := size.wrapped()
+	return C.iggInvisibleButton(idArg, sizeArg) != 0
+}
+
+// InvisibleButton calls InvisibleButtonV(id, Vec2{0,0}).
+func InvisibleButton(id string) bool {
+	return InvisibleButtonV(id, Vec2{})
+}
+
 // ImageV adds an image based on given texture ID.
 // Refer to TextureID what this represents and how it is drawn.
 func ImageV(id TextureID, size Vec2, uv0, uv1 Vec2, tintCol, borderCol Vec4) {
@@ -716,6 +729,19 @@ func TextLineHeightWithSpacing() float32 {
 	return float32(C.iggGetTextLineHeightWithSpacing())
 }
 
+// FrameHeight returns the height of the current frame. This is equal to the
+// font size plus the padding at the top and bottom.
+func FrameHeight() float32 {
+	return float32(C.iggGetFrameHeight())
+}
+
+// FrameHeightWithSpacing returns the height of the current frame with the item
+// spacing added. This is equal to the font size plus the padding at the top
+// and bottom, plus the value of style.ItemSpacing.y
+func FrameHeightWithSpacing() float32 {
+	return float32(C.iggGetFrameHeightWithSpacing())
+}
+
 // TreeNodeV returns true if the tree branch is to be rendered. Call TreePop() in this case.
 func TreeNodeV(label string, flags int) bool {
 	labelArg, labelFin := wrapString(label)
@@ -980,6 +1006,12 @@ func EndPopup() {
 // Clicking on a MenuItem or Selectable automatically close the current popup.
 func CloseCurrentPopup() {
 	C.iggCloseCurrentPopup()
+}
+
+// IsItemClicked returns true if the current item is clicked with the left
+// mouse button.
+func IsItemClicked() bool {
+	return C.iggIsItemClicked() != 0
 }
 
 // IsItemHoveredV returns true if the last item is hovered.

--- a/imgui.go
+++ b/imgui.go
@@ -1035,6 +1035,11 @@ func IsAnyItemActive() bool {
 	return C.iggIsAnyItemActive() != 0
 }
 
+// IsItemVisible returns true if the last item is visible
+func IsItemVisible() bool {
+	return C.iggIsItemVisible() != 0
+}
+
 // IsWindowAppearing returns whether the current window is appearing.
 func IsWindowAppearing() bool {
 	return C.iggIsWindowAppearing() != 0

--- a/imguiWrapper.cpp
+++ b/imguiWrapper.cpp
@@ -599,6 +599,11 @@ IggBool iggIsAnyItemActive()
    return ImGui::IsAnyItemActive() ? 1 : 0;
 }
 
+IggBool iggIsItemVisible()
+{
+   return ImGui::IsItemVisible() ? 1 : 0;
+}
+
 IggBool iggIsWindowAppearing() {
    return ImGui::IsWindowAppearing() ? 1 : 0;
 }

--- a/imguiWrapper.cpp
+++ b/imguiWrapper.cpp
@@ -244,6 +244,12 @@ IggBool iggButton(char const *label, IggVec2 const *size)
    return ImGui::Button(label, *sizeArg) ? 1 : 0;
 }
 
+IggBool iggInvisibleButton(char const *label, IggVec2 const *size)
+{
+   Vec2Wrapper sizeArg(size);
+   return ImGui::InvisibleButton(label, *sizeArg) ? 1 : 0;
+}
+
 void iggImage(IggTextureID textureID,
               IggVec2 const *size, IggVec2 const *uv0, IggVec2 const *uv1,
               IggVec4 const *tintCol, IggVec4 const *borderCol)
@@ -444,6 +450,16 @@ float iggGetTextLineHeightWithSpacing(void)
    return ImGui::GetTextLineHeightWithSpacing();
 }
 
+float iggGetFrameHeight(void)
+{
+   return ImGui::GetFrameHeight();
+}
+
+float iggGetFrameHeightWithSpacing(void)
+{
+   return ImGui::GetFrameHeightWithSpacing();
+}
+
 IggBool iggTreeNode(char const *label, int flags)
 {
    return ImGui::TreeNodeEx(label, flags) ? 1 : 0;
@@ -561,6 +577,11 @@ void iggEndPopup(void)
 void iggCloseCurrentPopup(void)
 {
    ImGui::CloseCurrentPopup();
+}
+
+IggBool iggIsItemClicked()
+{
+   return ImGui::IsItemClicked() ? 1 : 0;
 }
 
 IggBool iggIsItemHovered(int flags)

--- a/imguiWrapper.h
+++ b/imguiWrapper.h
@@ -64,6 +64,7 @@ extern void iggTextUnformatted(char const *text);
 extern void iggLabelText(char const *label, char const *text);
 
 extern IggBool iggButton(char const *label, IggVec2 const *size);
+extern IggBool iggInvisibleButton(char const *label, IggVec2 const *size);
 extern void iggImage(IggTextureID textureID,
 	IggVec2 const *size, IggVec2 const *uv0, IggVec2 const *uv1,
 	IggVec4 const *tintCol, IggVec4 const *borderCol);
@@ -113,6 +114,8 @@ extern void iggSetCursorScreenPos(IggVec2 const *absPos);
 extern void iggAlignTextToFramePadding();
 extern float iggGetTextLineHeight(void);
 extern float iggGetTextLineHeightWithSpacing(void);
+extern float iggGetFrameHeight(void);
+extern float iggGetFrameHeightWithSpacing(void);
 
 extern IggBool iggTreeNode(char const *label, int flags);
 extern void iggTreePop(void);
@@ -143,6 +146,7 @@ extern IggBool iggBeginPopupContextItem(char const *label, int mouseButton);
 extern void iggEndPopup(void);
 extern void iggCloseCurrentPopup(void);
 
+extern IggBool iggIsItemClicked();
 extern IggBool iggIsItemHovered(int flags);
 extern IggBool iggIsItemActive();
 extern IggBool iggIsAnyItemActive();

--- a/imguiWrapper.h
+++ b/imguiWrapper.h
@@ -150,6 +150,7 @@ extern IggBool iggIsItemClicked();
 extern IggBool iggIsItemHovered(int flags);
 extern IggBool iggIsItemActive();
 extern IggBool iggIsAnyItemActive();
+extern IggBool iggIsItemVisible();
 
 extern IggBool iggIsWindowAppearing();
 extern IggBool iggIsWindowCollapsed();

--- a/imguiWrapperTypes.h
+++ b/imguiWrapperTypes.h
@@ -19,6 +19,7 @@ typedef void *IggGlyphRanges;
 typedef void *IggGuiStyle;
 typedef void *IggInputTextCallbackData;
 typedef void *IggIO;
+typedef unsigned int ImU32;  // 32-bit unsigned integer (often used to store packed colors)
 
 typedef struct tagIggVec2
 {


### PR DESCRIPTION
The DrawList functions (AddRect(), AddCircle(), etc.) take a colour argument of uint32, which is different to how colour is specified in other parts of the library.

The Dear Imgui code contains helper functions and macros to convert from the usual Vec4{} representation to uint32. I've not added them to imgui-go because I wasn't sure how you wanted to go about it - there are no existing helper functions/macros to use as a template.

This is what I'm using in my code at the moment, based on the macros/functions in Dear Imgui.

```
func float32ToUint32(f float32) uint32 {
	s := f
	if s < 0.0 {
		s = 0.0
	} else if s > 1.0 {
		s = 1.0
	}

	return uint32(s*255.0 + 0.5)
}

// colorConvertFloat4ToU32 converts a color represented by a four-dimensional
// vector to an unsigned 32bit integer.
func colorConvertFloat4ToU32(col imgui.Vec4) uint32 {
	var r uint32
	r = float32ToUint32(col.X) << 0
	r |= float32ToUint32(col.Y) << 8
	r |= float32ToUint32(col.Z) << 16
	r |= float32ToUint32(col.W) << 24
	return r
}
```
