### PR TITLE
Added ItemSpacing() to Style

### DIFF
--- a/Style.go
+++ b/Style.go
@@ -117,6 +117,15 @@ func (style Style) handle() C.IggGuiStyle {
 	return C.IggGuiStyle(style)
 }
 
+// ItemInnerSpacing is the horizontal and vertical spacing between widgets/lines
+func (style Style) ItemSpacing() Vec2 {
+	var value Vec2
+	valueArg, valueFin := value.wrapped()
+	C.iggStyleGetItemSpacing(style.handle(), valueArg)
+	valueFin()
+	return value
+}
+
 // ItemInnerSpacing is the horizontal and vertical spacing between elements of
 // a composed widget (e.g. a slider and its label).
 func (style Style) ItemInnerSpacing() Vec2 {

--- a/StyleWrapper.cpp
+++ b/StyleWrapper.cpp
@@ -8,6 +8,12 @@ void iggStyleGetItemInnerSpacing(IggGuiStyle handle, IggVec2 *value)
    exportValue(*value, style->ItemInnerSpacing);
 }
 
+void iggStyleGetItemSpacing(IggGuiStyle handle, IggVec2 *value)
+{
+   ImGuiStyle *style = reinterpret_cast<ImGuiStyle *>(handle);
+   exportValue(*value, style->ItemSpacing);
+}
+
 void iggStyleGetFramePadding(IggGuiStyle handle, IggVec2 *value)
 {
    ImGuiStyle *style = reinterpret_cast<ImGuiStyle *>(handle);

--- a/StyleWrapper.h
+++ b/StyleWrapper.h
@@ -7,6 +7,8 @@ extern "C"
 {
 #endif
 
+extern void iggStyleGetItemSpacing(IggGuiStyle handle, IggVec2 *value);
+
 extern void iggStyleGetItemInnerSpacing(IggGuiStyle handle, IggVec2 *value);
 
 extern void iggStyleGetFramePadding(IggGuiStyle handle, IggVec2 *value);


### PR DESCRIPTION
Useful for adding a group of fixed height with space for an exact number of widgets below.

This is used in the console demo for ensuring there's space for the input field after the output