### PR TITLE
Feature/linter as action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,5 +1,5 @@
 name: golangci-lint
-on: [push, pull-request]
+on: [push, pull_request]
 jobs:
 
   build:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install golangci-lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
+        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on: [push, pull-request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Print go version
+        run: go version
+      - name: Check out module
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Install golangci-lint
+        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
+
+      - name: Run golangci-lint
+        run: $(go env GOPATH)/bin/golangci-lint run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.12, 1.13]
+        go-version: [1.12, 1.13, 1.14]
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
     - name: Set up Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 service:
-  golangci-lint-version: 1.21.x
+  golangci-lint-version: 1.27.x
 
 run:
   deadline: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - goimports # disabled because of so many false-positives with "imgui-go"
+    - godot # TODO: enable this as soon as big refactoring is done (cpp in sub-directory).
     - gosec
     - maligned
     - dupl

--- a/AllocatedGlyphRanges.go
+++ b/AllocatedGlyphRanges.go
@@ -27,8 +27,10 @@ type GlyphRangesBuilder struct {
 // Build combines all the currently registered ranges and creates a new instance.
 // The returned ranges object needs to be explicitly freed in order to release resources.
 func (builder *GlyphRangesBuilder) Build() AllocatedGlyphRanges {
+	const bytesPerUint16 = 2
+	const uint16PerRangeEntry = 2
 	ranges := builder.mergedRanges()
-	raw := C.malloc(C.size_t(2 * ((len(ranges) * 2) + 1)))
+	raw := C.malloc(C.size_t(bytesPerUint16 * ((len(ranges) * uint16PerRangeEntry) + 1)))
 	rawSlice := (*[1 << 30]uint16)(raw)[:]
 	outIndex := 0
 	for _, r := range ranges {

--- a/Assert.go
+++ b/Assert.go
@@ -2,20 +2,34 @@ package imgui
 
 import "C"
 import (
-	"errors"
 	"fmt"
 )
 
 // AssertHandler is a handler for an assertion that happened in the native part of ImGui.
 type AssertHandler func(expression string, file string, line int)
 
-var assertHandler AssertHandler = func(expression string, file string, line int) {
-	message := fmt.Sprintf(`Assertion failed!
+// AssertionError is the standard error being thrown by the default handler.
+type AssertionError struct {
+	Expression string
+	File       string
+	Line       int
+}
+
+// Error returns the string representation.
+func (err AssertionError) Error() string {
+	return fmt.Sprintf(`Assertion failed!
 File: %s, Line %d
 
 Expression: %s
-`, file, line, expression)
-	panic(errors.New(message))
+`, err.File, err.Line, err.Expression)
+}
+
+var assertHandler AssertHandler = func(expression string, file string, line int) {
+	panic(AssertionError{
+		Expression: expression,
+		File:       file,
+		Line:       line,
+	})
 }
 
 // SetAssertHandler registers a handler function for all future assertions.

--- a/ColorEditFlags.go
+++ b/ColorEditFlags.go
@@ -19,16 +19,20 @@ const (
 	ColorEditFlagsNoLabel
 	// ColorEditFlagsNoDragDrop disables drag and drop target. ColorButton: disable drag and drop source.
 	ColorEditFlagsNoDragDrop
+)
 
-	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions(). The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call SetColorEditOptions() during startup.
-
+// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions().
+// The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call
+// SetColorEditOptions() during startup.
+const (
 	// ColorEditFlagsAlphaBar shows vertical alpha bar/gradient in picker.
 	ColorEditFlagsAlphaBar = 1 << 16
 	// ColorEditFlagsAlphaPreview displays preview as a transparent color over a checkerboard, instead of opaque.
 	ColorEditFlagsAlphaPreview = 1 << 17
 	// ColorEditFlagsAlphaPreviewHalf displays half opaque / half checkerboard, instead of opaque.
 	ColorEditFlagsAlphaPreviewHalf = 1 << 18
-	// ColorEditFlagsHDR = (WIP) surrently only disable 0.0f..1.0f limits in RGBA edition (note: you probably want to use ImGuiColorEditFlags_Float flag as well).
+	// ColorEditFlagsHDR = (WIP) currently only disable 0.0f..1.0f limits in RGBA edition.
+	// Mote: you probably want to use ColorEditFlagsFloat flag as well.
 	ColorEditFlagsHDR = 1 << 19
 	// ColorEditFlagsRGB sets the format as RGB
 	ColorEditFlagsRGB = 1 << 20

--- a/ColorEditFlags.go
+++ b/ColorEditFlags.go
@@ -2,7 +2,7 @@ package imgui
 
 const (
 	// ColorEditFlagsNone default = 0
-	ColorEditFlagsNone           = 0
+	ColorEditFlagsNone = 0
 	// ColorEditFlagsNoAlpha ignores Alpha component (read 3 components from the input pointer).
 	ColorEditFlagsNoAlpha = 1 << iota
 	// ColorEditFlagsNoPicker disables picker when clicking on colored square.
@@ -23,21 +23,21 @@ const (
 	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions(). The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call SetColorEditOptions() during startup.
 
 	// ColorEditFlagsAlphaBar shows vertical alpha bar/gradient in picker.
-	ColorEditFlagsAlphaBar         = 1 << 16
+	ColorEditFlagsAlphaBar = 1 << 16
 	// ColorEditFlagsAlphaPreview displays preview as a transparent color over a checkerboard, instead of opaque.
-	ColorEditFlagsAlphaPreview     = 1 << 17
+	ColorEditFlagsAlphaPreview = 1 << 17
 	// ColorEditFlagsAlphaPreviewHalf displays half opaque / half checkerboard, instead of opaque.
 	ColorEditFlagsAlphaPreviewHalf = 1 << 18
 	// ColorEditFlagsHDR = (WIP) surrently only disable 0.0f..1.0f limits in RGBA edition (note: you probably want to use ImGuiColorEditFlags_Float flag as well).
-	ColorEditFlagsHDR              = 1 << 19
+	ColorEditFlagsHDR = 1 << 19
 	// ColorEditFlagsRGB sets the format as RGB
-	ColorEditFlagsRGB              = 1 << 20
+	ColorEditFlagsRGB = 1 << 20
 	// ColorEditFlagsHSV sets the format as HSV
-	ColorEditFlagsHSV              = 1 << 21
+	ColorEditFlagsHSV = 1 << 21
 	// ColorEditFlagsHEX sets the format as HEX
-	ColorEditFlagsHEX              = 1 << 22
+	ColorEditFlagsHEX = 1 << 22
 	// ColorEditFlagsUint8 _display_ values formatted as 0..255.
-	ColorEditFlagsUint8            = 1 << 23
+	ColorEditFlagsUint8 = 1 << 23
 	// ColorEditFlagsFloat _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.
-	ColorEditFlagsFloat            = 1 << 24
+	ColorEditFlagsFloat = 1 << 24
 )

--- a/ColorPickerFlags.go
+++ b/ColorPickerFlags.go
@@ -15,9 +15,12 @@ const (
 	ColorPickerFlagsNoLabel = 1 << 7
 	// ColorPickerFlagsNoSidePreview disables bigger color preview on right side of the picker, use small colored square preview instead.
 	ColorPickerFlagsNoSidePreview = 1 << 8
+)
 
-	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions(). The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call SetColorPickerOptions() during startup.
-
+// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions().
+// The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call
+// SetColorPickerOptions() during startup.
+const (
 	// ColorPickerFlagsAlphaBar shows vertical alpha bar/gradient in picker.
 	ColorPickerFlagsAlphaBar = 1 << 16
 	// ColorPickerFlagsAlphaPreview displays preview as a transparent color over a checkerboard, instead of opaque.

--- a/ColorPickerFlags.go
+++ b/ColorPickerFlags.go
@@ -2,7 +2,7 @@ package imgui
 
 const (
 	// ColorPickerFlagsNone default = 0
-	ColorPickerFlagsNone           = 0
+	ColorPickerFlagsNone = 0
 	// ColorPickerFlagsNoAlpha ignoreс Alpha component (read 3 components from the input pointer).
 	ColorPickerFlagsNoAlpha = 1 << iota
 	// ColorPickerFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs)
@@ -19,23 +19,23 @@ const (
 	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions(). The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call SetColorPickerOptions() during startup.
 
 	// ColorPickerFlagsAlphaBar shows vertical alpha bar/gradient in picker.
-	ColorPickerFlagsAlphaBar         = 1 << 16
+	ColorPickerFlagsAlphaBar = 1 << 16
 	// ColorPickerFlagsAlphaPreview displays preview as a transparent color over a checkerboard, instead of opaque.
-	ColorPickerFlagsAlphaPreview     = 1 << 17
+	ColorPickerFlagsAlphaPreview = 1 << 17
 	// ColorPickerFlagsAlphaPreviewHalf displays half opaque / half checkerboard, instead of opaque.
 	ColorPickerFlagsAlphaPreviewHalf = 1 << 18
 	// ColorPickerFlagsRGB sets the format as RGB
-	ColorPickerFlagsRGB              = 1 << 20
+	ColorPickerFlagsRGB = 1 << 20
 	// ColorPickerFlagsHSV sets the format as HSV
-	ColorPickerFlagsHSV              = 1 << 21
+	ColorPickerFlagsHSV = 1 << 21
 	// ColorPickerFlagsHEX sets the format as HEX
-	ColorPickerFlagsHEX              = 1 << 22
+	ColorPickerFlagsHEX = 1 << 22
 	// ColorPickerFlagsUint8 _display_ values formatted as 0..255.
-	ColorPickerFlagsUint8            = 1 << 23
+	ColorPickerFlagsUint8 = 1 << 23
 	// ColorPickerFlagsFloat _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.
-	ColorPickerFlagsFloat            = 1 << 24
+	ColorPickerFlagsFloat = 1 << 24
 	// ColorPickerFlagsPickerHueBar bar for Hue, rectangle for Sat/Value.
-	ColorPickerFlagsPickerHueBar     = 1 << 25
+	ColorPickerFlagsPickerHueBar = 1 << 25
 	// ColorPickerFlagsPickerHueWheel wheel for Hue, triangle for Sat/Value.
-	ColorPickerFlagsPickerHueWheel   = 1 << 26
+	ColorPickerFlagsPickerHueWheel = 1 << 26
 )

--- a/Context_test.go
+++ b/Context_test.go
@@ -1,4 +1,4 @@
-package imgui
+package imgui // nolint: testpackage
 
 import (
 	"fmt"

--- a/Context_test.go
+++ b/Context_test.go
@@ -35,7 +35,7 @@ func TestCurrentContextCanBeChanged(t *testing.T) {
 	defer context1.Destroy()
 
 	first, _ := CurrentContext()
-	assert.True(t, context1.handle == first.handle, fmt.Sprintf("First context expected"))
+	assert.True(t, context1.handle == first.handle, "First context expected")
 
 	context2 := CreateContext(nil)
 	require.NotNil(t, context2, "Context expected")

--- a/DragDrop.go
+++ b/DragDrop.go
@@ -3,7 +3,7 @@ package imgui
 // #include "DragDropWrapper.h"
 import "C"
 
-// BeginDragDropSource flags
+// This is a list of BeginDragDropSource flags.
 const (
 	// DragDropFlagsNone specifies the default behaviour.
 	DragDropFlagsNone = 0
@@ -31,7 +31,10 @@ const (
 
 // BeginDragDropSource opens the scope for current draw and drop source.
 // Call when current ID is active.
-// When this returns true you need to: a) call SetDragDropPayload() exactly once, b) you may render the payload visual/description, c) call EndDragDropSource()
+// When this returns true you need to:
+// a) call SetDragDropPayload() exactly once,
+// b) you may render the payload visual/description,
+// c) call EndDragDropSource().
 func BeginDragDropSource(flags int) bool {
 	return C.iggBeginDragDropSource(C.int(flags)) != 0
 }

--- a/DrawList.go
+++ b/DrawList.go
@@ -91,7 +91,7 @@ func WindowDrawList() DrawList {
 	return DrawList(C.iggGetWindowDrawList())
 }
 
-// List of DrawCornerFlags
+// This is a list of DrawCornerFlags.
 const (
 	DrawCornerFlagsNone     = 0x0
 	DrawCornerFlagsTopLeft  = 0x1
@@ -105,20 +105,19 @@ const (
 	DrawCornerFlagsAll      = 0xF
 )
 
-// AddLine call AddLineV with a thickness value of 1.0
+// AddLine call AddLineV with a thickness value of 1.0.
 func (list DrawList) AddLine(p1 Vec2, p2 Vec2, col PackedColor) {
 	list.AddLineV(p1, p2, col, 1.0)
 }
 
-// AddLineV adds a line to draw list, extending from point p1 to p2
+// AddLineV adds a line to draw list, extending from point p1 to p2.
 func (list DrawList) AddLineV(p1 Vec2, p2 Vec2, col PackedColor, thickness float32) {
 	p1Arg, _ := p1.wrapped()
 	p2Arg, _ := p2.wrapped()
 	C.iggAddLine(list.handle(), p1Arg, p2Arg, C.IggPackedColor(col), C.float(thickness))
 }
 
-// AddRect calls AddRectV with rounding and thickness values of 1.0 and
-// DrawCornerFlagsAll
+// AddRect calls AddRectV with rounding and thickness values of 1.0 and DrawCornerFlagsAll.
 func (list DrawList) AddRect(min Vec2, max Vec2, col PackedColor) {
 	list.AddRectV(min, max, col, 1.0, DrawCornerFlagsAll, 1.0)
 }

--- a/FocusedFlags.go
+++ b/FocusedFlags.go
@@ -8,7 +8,9 @@ const (
 	FocusedFlagsChildWindows = 1 << 0
 	// FocusedFlagsRootWindow tests from root window (top most parent of the current hierarchy)
 	FocusedFlagsRootWindow = 1 << 1
-	// FocusedFlagsAnyWindow returns true if any window is focused. Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this. Use WantCaptureMouse instead.
+	// FocusedFlagsAnyWindow returns true if any window is focused.
+	// Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this.
+	// Use WantCaptureMouse instead.
 	FocusedFlagsAnyWindow = 1 << 2
 )
 

--- a/FocusedFlags.go
+++ b/FocusedFlags.go
@@ -12,7 +12,7 @@ const (
 	FocusedFlagsAnyWindow = 1 << 2
 )
 
-// FocusedFlags combinations
+// This is a list of FocusedFlags combinations.
 const (
 	FocusedFlagsRootAndChildWindows = FocusedFlagsRootWindow | FocusedFlagsChildWindows
 )

--- a/HoveredFlags.go
+++ b/HoveredFlags.go
@@ -21,7 +21,7 @@ const (
 	HoveredFlagsAllowWhenDisabled = 1 << 7
 )
 
-// HoveredFlags combinations
+// This is a list of HoveredFlags combinations.
 const (
 	HoveredFlagsRectOnly            = HoveredFlagsAllowWhenBlockedByPopup | HoveredFlagsAllowWhenBlockedByActiveItem | HoveredFlagsAllowWhenOverlapped
 	HoveredFlagsRootAndChildWindows = HoveredFlagsRootWindow | HoveredFlagsChildWindows

--- a/MouseCursorFlags.go
+++ b/MouseCursorFlags.go
@@ -1,7 +1,8 @@
 package imgui
 
-// Enumeration for MouseCursor()
-// User code may request binding to display given cursor by calling SetMouseCursor(), which is why we have some cursors that are marked unused here
+// This is a list of enumeration values for MouseCursor().
+// User code may request binding to display given cursor by calling SetMouseCursor(),
+// which is why we have some cursors that are marked unused here.
 const (
 	// MouseCursorNone no mouse cursor
 	MouseCursorNone = -1

--- a/PackedColor.go
+++ b/PackedColor.go
@@ -1,6 +1,9 @@
 package imgui
 
-import "image/color"
+import (
+	"image/color"
+	"math"
+)
 
 // PackedColor is a 32-bit RGBA color value, with 8 bits per color channel.
 // The bytes are assigned as 0xAABBGGRR.
@@ -39,12 +42,12 @@ func Packed(c color.Color) PackedColor {
 // PackedColorFromVec4 converts the given four-dimensional vector into a packed color.
 func PackedColorFromVec4(vec Vec4) PackedColor {
 	convert := func(f float32) uint32 {
-		scaled := (f * 255.0) + 0.5
+		scaled := (f * math.MaxUint8) + 0.5 // nolint: gomnd
 		switch {
-		case scaled <= 0.0:
-			return 0x00
-		case scaled >= 255.0:
-			return 0xFF
+		case scaled <= 0:
+			return 0
+		case scaled >= math.MaxUint8:
+			return math.MaxUint8
 		default:
 			return uint32(scaled)
 		}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Doc](https://godoc.org/github.com/inkyblackness/imgui-go?status.svg)](https://godoc.org/github.com/inkyblackness/imgui-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/inkyblackness/imgui-go)](https://goreportcard.com/report/github.com/inkyblackness/imgui-go)
-[![GolangCI](https://golangci.com/badges/github.com/inkyblackness/imgui-go.svg)](https://golangci.com)
+[![Lint Status](https://github.com/inkyblackness/imgui-go/workflows/golangci-lint/badge.svg)](https://github.com/inkyblackness/imgui-go/actions)
 
 This library is a [Go](https://www.golang.org) wrapper for **[Dear ImGui](https://github.com/ocornut/imgui)**.
 

--- a/WrapperConverter_test.go
+++ b/WrapperConverter_test.go
@@ -1,4 +1,4 @@
-package imgui
+package imgui // nolint: testpackage
 
 import (
 	"fmt"

--- a/imgui.go
+++ b/imgui.go
@@ -314,9 +314,9 @@ func PushTextWrapPosV(wrapPosX float32) {
 	C.iggPushTextWrapPos(C.float(wrapPosX))
 }
 
-// PushTextWrapPos calls PushTextWrapPosV(0.0).
+// PushTextWrapPos calls PushTextWrapPosV(0).
 func PushTextWrapPos() {
-	PushTextWrapPosV(0.0)
+	PushTextWrapPosV(0)
 }
 
 // PopTextWrapPos resets the last pushed position.


### PR DESCRIPTION
Since `golangci` has stopped their online services, the linter needed to be re-integrated using actions.
This way, future pull requests will be guarded again.