### PR TITLE
fixed build error on 32bit systems with pointer-to-slice casts

### DIFF
--- a/AllocatedGlyphRanges.go
+++ b/AllocatedGlyphRanges.go
@@ -31,7 +31,7 @@ func (builder *GlyphRangesBuilder) Build() AllocatedGlyphRanges {
 	const uint16PerRangeEntry = 2
 	ranges := builder.mergedRanges()
 	raw := C.malloc(C.size_t(bytesPerUint16 * ((len(ranges) * uint16PerRangeEntry) + 1)))
-	rawSlice := (*[1 << 30]uint16)(raw)[:]
+	rawSlice := ptrToUint16Slice(raw)
 	outIndex := 0
 	for _, r := range ranges {
 		rawSlice[outIndex+0] = r.from

--- a/FontAtlas.go
+++ b/FontAtlas.go
@@ -103,7 +103,7 @@ func (atlas FontAtlas) AddFontFromMemoryTTFV(
 	}
 
 	fontDataC := C.malloc(C.size_t(len(fontData)))
-	cBuf := (*[1 << 30]byte)(fontDataC)
+	cBuf := ptrToByteSlice(fontDataC)
 
 	copy(cBuf[:], fontData)
 

--- a/FontAtlas.go
+++ b/FontAtlas.go
@@ -105,7 +105,7 @@ func (atlas FontAtlas) AddFontFromMemoryTTFV(
 	fontDataC := C.malloc(C.size_t(len(fontData)))
 	cBuf := ptrToByteSlice(fontDataC)
 
-	copy(cBuf[:], fontData)
+	copy(cBuf, fontData)
 
 	fontHandle := C.iggAddFontFromMemoryTTF(atlas.handle(), (*C.char)(fontDataC), C.int(len(fontData)), C.float(sizePixels),
 		config.handle(), glyphRange.handle())

--- a/GlyphRanges.go
+++ b/GlyphRanges.go
@@ -21,7 +21,7 @@ func (glyphs GlyphRanges) extract() (result []glyphRange) {
 	if glyphs == 0 {
 		return
 	}
-	rawSlice := (*[1 << 30]uint16)(unsafe.Pointer(glyphs.handle()))[:]
+	rawSlice := ptrToUint16Slice(unsafe.Pointer(glyphs.handle()))
 	index := 0
 	// iterate until end of list or an arbitrary paranoia limit, should the list not be proper.
 	for (rawSlice[index] != 0) && (index < 1000) {

--- a/InputTextCallbackData.go
+++ b/InputTextCallbackData.go
@@ -125,7 +125,7 @@ func (data InputTextCallbackData) Buffer() []byte {
 		return nil
 	}
 	textLen := data.bufTextLen()
-	return ((*[1 << 30]byte)(unsafe.Pointer(ptr)))[:textLen]
+	return ptrToByteSlice(unsafe.Pointer(ptr))[:textLen]
 }
 
 // MarkBufferModified indicates that the content of the buffer was modified during a callback.


### PR DESCRIPTION
As part of this, these casts were centralized, with an explanation what to do. The compiler most likely inlines them again, anyway.

This fixes #84 and #113 .