### PR TITLE
Add support for WindowContentRegion{Min,Max,Width}

### DIFF
--- a/Window.go
+++ b/Window.go
@@ -171,6 +171,30 @@ func ContentRegionMax() Vec2 {
 	return out
 }
 
+// WindowContentRegionMin returns the content boundaries min (roughly (0,0)-Scroll), in window coordinates.
+func WindowContentRegionMin() Vec2 {
+	out := Vec2{}
+	outArg, outFin := out.wrapped()
+	C.iggGetWindowContentRegionMin(outArg)
+	outFin()
+	return out
+}
+
+// WindowContentRegionMax returns the content boundaries max (roughly (0,0)+Size-Scroll) where Size can be overridden
+// with SetNextWindowContentSize(), in window coordinates.
+func WindowContentRegionMax() Vec2 {
+	out := Vec2{}
+	outArg, outFin := out.wrapped()
+	C.iggGetWindowContentRegionMax(outArg)
+	outFin()
+	return out
+}
+
+// WindowContentRegionWidth returns the width of the content boundary, in window coordinates.
+func WindowContentRegionWidth() float32 {
+	return float32(C.iggGetWindowContentRegionWidth())
+}
+
 // SetNextWindowPosV sets next window position.
 // Call before Begin(). Use pivot=(0.5,0.5) to center on given point, etc.
 func SetNextWindowPosV(pos Vec2, cond Condition, pivot Vec2) {

--- a/wrapper/Window.cpp
+++ b/wrapper/Window.cpp
@@ -68,6 +68,23 @@ void iggGetContentRegionMax(IggVec2 *out)
    exportValue(*out, im_out);
 }
 
+void iggGetWindowContentRegionMin(IggVec2 *out)
+{
+	ImVec2 im_out = ImGui::GetWindowContentRegionMin();
+	exportValue(*out, im_out);
+}
+
+void iggGetWindowContentRegionMax(IggVec2 *out)
+{
+	ImVec2 im_out = ImGui::GetWindowContentRegionMax();
+	exportValue(*out, im_out);
+}
+
+float iggGetWindowContentRegionWidth()
+{
+	return ImGui::GetWindowContentRegionWidth();
+}
+
 void iggSetNextWindowPos(IggVec2 const *pos, int cond, IggVec2 const *pivot)
 {
    Vec2Wrapper posArg(pos);

--- a/wrapper/Window.h
+++ b/wrapper/Window.h
@@ -20,6 +20,9 @@ extern float iggWindowWidth(void);
 extern float iggWindowHeight(void);
 extern void iggContentRegionAvail(IggVec2 *size);
 extern void iggGetContentRegionMax(IggVec2 *out);
+extern void iggGetWindowContentRegionMin(IggVec2 *out);
+extern void iggGetWindowContentRegionMax(IggVec2 *out);
+extern float iggGetWindowContentRegionWidth();
 
 extern void iggSetNextWindowPos(IggVec2 const *pos, int cond, IggVec2 const *pivot);
 extern void iggSetNextWindowSize(IggVec2 const *size, int cond);


### PR DESCRIPTION
Provide access to the window content region boundary.
These are helpful when trying to map from a mouse position back
to a coordinate within the content of a window - particularly
if the window is scrolling over larger content.