### PR TITLE
Add CollapsingHeaderV with flags parameter

### DIFF
--- a/Widgets.go
+++ b/Widgets.go
@@ -818,9 +818,14 @@ func ColorPicker4V(label string, col *[4]float32, flags int) bool {
 
 // CollapsingHeader adds a collapsing header.
 func CollapsingHeader(label string) bool {
+	return CollapsingHeaderV(label, 0)
+}
+
+// CollapsingHeader adds a collapsing header.
+func CollapsingHeaderV(label string, flags int) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
-	return C.iggCollapsingHeader(labelArg) != 0
+	return C.iggCollapsingHeader(labelArg, C.int(flags)) != 0
 }
 
 const (

--- a/Widgets.go
+++ b/Widgets.go
@@ -816,7 +816,7 @@ func ColorPicker4V(label string, col *[4]float32, flags int) bool {
 	return C.iggColorPicker4(labelArg, ccol, C.int(flags)) != 0
 }
 
-// CollapsingHeader adds a collapsing header.
+// CollapsingHeader calls CollapsingHeaderV(label, 0).
 func CollapsingHeader(label string) bool {
 	return CollapsingHeaderV(label, 0)
 }

--- a/Widgets.go
+++ b/Widgets.go
@@ -821,7 +821,7 @@ func CollapsingHeader(label string) bool {
 	return CollapsingHeaderV(label, 0)
 }
 
-// CollapsingHeader adds a collapsing header.
+// CollapsingHeaderV adds a collapsing header with TreeNode flags.
 func CollapsingHeaderV(label string, flags int) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()

--- a/wrapper/Widgets.cpp
+++ b/wrapper/Widgets.cpp
@@ -193,9 +193,9 @@ IggBool iggColorPicker4(char const *label, float *col, int flags)
    return ImGui::ColorPicker4(label, col, flags) ? 1 : 0;
 }
 
-IggBool iggCollapsingHeader(const char *label)
+IggBool iggCollapsingHeader(const char *label, int flags)
 {
-   return ImGui::CollapsingHeader(label) ? 1 : 0;
+   return ImGui::CollapsingHeader(label, flags) ? 1 : 0;
 }
 
 IggBool iggTreeNode(char const *label, int flags)

--- a/wrapper/Widgets.h
+++ b/wrapper/Widgets.h
@@ -57,7 +57,7 @@ extern void iggTreePop(void);
 extern void iggSetNextItemOpen(IggBool open, int cond);
 extern float iggGetTreeNodeToLabelSpacing(void);
 
-extern IggBool iggCollapsingHeader(const char *label);
+extern IggBool iggCollapsingHeader(const char *label, int flags);
 
 extern IggBool iggSelectable(char const *label, IggBool selected, int flags, IggVec2 const *size);
 extern IggBool iggListBoxV(char const *label, int *currentItem, char const *const items[], int itemCount, int heightItems);


### PR DESCRIPTION
This allows TreeNode flags to be passed along. In particular it's useful for having headers default to open:
```
if imgui.CollapsingHeaderV("Header", imgui.TreeNodeFlagsDefaultOpen) {
  // ....
}
```