### PR TITLE
Add a few more DrawList functions

### DIFF
--- a/DrawList.go
+++ b/DrawList.go
@@ -10,7 +10,7 @@ import (
 // This is the low-level list of polygons that ImGui functions are filling.
 // At the end of the frame, all command lists are passed to your render function for rendering.
 //
-// Each ImGui window contains its own DrawList. You can use GetWindowDrawList() to access
+// Each ImGui window contains its own DrawList. You can use WindowDrawList() to access
 // the current window draw list and draw custom primitives.
 //
 // You can interleave normal ImGui calls and adding primitives to the current draw list.
@@ -91,6 +91,7 @@ func WindowDrawList() DrawList {
 	return DrawList(C.iggGetWindowDrawList())
 }
 
+// BackgroundDrawList returns the DrawList for the background behind all windows.
 func BackgroundDrawList() DrawList {
 	return DrawList(C.iggGetBackgroundDrawList())
 }
@@ -196,10 +197,17 @@ func (list DrawList) AddTriangleFilled(p1 Vec2, p2 Vec2, p3 Vec2, col PackedColo
 	C.iggAddTriangleFilled(list.handle(), p1Arg, p2Arg, p3Arg, C.IggPackedColor(col))
 }
 
-func (list DrawList) AddImage(textureID TextureID, pMin Vec2, pMax Vec2, uvMin Vec2, uvMax Vec2, col PackedColor) {
-	pMinArg, _ := pMin.wrapped()
-	pMaxArg, _ := pMax.wrapped()
+// AddImage calls AddImageV(textureId, posMin, posMax, Vec2{0,0}, Vec2{1,1}, PackedColor(0xffffffff))
+func (list DrawList) AddImage(textureID TextureID, posMin Vec2, posMax Vec2) {
+	// use white tint by default
+	list.AddImageV(textureID, posMin, posMax, Vec2{X: 0, Y: 0}, Vec2{X: 1, Y: 1}, PackedColor(0xffffffff))
+}
+
+// AddImageV adds an image based on given texture ID.
+func (list DrawList) AddImageV(textureID TextureID, posMin Vec2, posMax Vec2, uvMin Vec2, uvMax Vec2, tintCol PackedColor) {
+	posMinArg, _ := posMin.wrapped()
+	posMaxArg, _ := posMax.wrapped()
 	uvMinArg, _ := uvMin.wrapped()
 	uvMaxArg, _ := uvMax.wrapped()
-	C.iggAddImage(list.handle(), C.IggTextureID(textureID), pMinArg, pMaxArg, uvMinArg, uvMaxArg, C.IggPackedColor(col))
+	C.iggAddImage(list.handle(), C.IggTextureID(textureID), posMinArg, posMaxArg, uvMinArg, uvMaxArg, C.IggPackedColor(tintCol))
 }

--- a/DrawList.go
+++ b/DrawList.go
@@ -91,6 +91,10 @@ func WindowDrawList() DrawList {
 	return DrawList(C.iggGetWindowDrawList())
 }
 
+func BackgroundDrawList() DrawList {
+	return DrawList(C.iggGetBackgroundDrawList())
+}
+
 // This is a list of DrawCornerFlags.
 const (
 	DrawCornerFlagsNone     = 0x0
@@ -190,4 +194,12 @@ func (list DrawList) AddTriangleFilled(p1 Vec2, p2 Vec2, p3 Vec2, col PackedColo
 	p2Arg, _ := p2.wrapped()
 	p3Arg, _ := p3.wrapped()
 	C.iggAddTriangleFilled(list.handle(), p1Arg, p2Arg, p3Arg, C.IggPackedColor(col))
+}
+
+func (list DrawList) AddImage(textureID TextureID, pMin Vec2, pMax Vec2, uvMin Vec2, uvMax Vec2, col PackedColor) {
+	pMinArg, _ := pMin.wrapped()
+	pMaxArg, _ := pMax.wrapped()
+	uvMinArg, _ := uvMin.wrapped()
+	uvMaxArg, _ := uvMax.wrapped()
+	C.iggAddImage(list.handle(), C.IggTextureID(textureID), pMinArg, pMaxArg, uvMinArg, uvMaxArg, C.IggPackedColor(col))
 }

--- a/DrawList.go
+++ b/DrawList.go
@@ -3,6 +3,7 @@ package imgui
 // #include "wrapper/DrawList.h"
 import "C"
 import (
+	"image/color"
 	"unsafe"
 )
 
@@ -197,10 +198,9 @@ func (list DrawList) AddTriangleFilled(p1 Vec2, p2 Vec2, p3 Vec2, col PackedColo
 	C.iggAddTriangleFilled(list.handle(), p1Arg, p2Arg, p3Arg, C.IggPackedColor(col))
 }
 
-// AddImage calls AddImageV(textureId, posMin, posMax, Vec2{0,0}, Vec2{1,1}, PackedColor(0xffffffff))
+// AddImage calls AddImageV(textureId, posMin, posMax, Vec2{0,0}, Vec2{1,1}, Packed(color.White)).
 func (list DrawList) AddImage(textureID TextureID, posMin Vec2, posMax Vec2) {
-	// use white tint by default
-	list.AddImageV(textureID, posMin, posMax, Vec2{X: 0, Y: 0}, Vec2{X: 1, Y: 1}, PackedColor(0xffffffff))
+	list.AddImageV(textureID, posMin, posMax, Vec2{X: 0, Y: 0}, Vec2{X: 1, Y: 1}, Packed(color.White))
 }
 
 // AddImageV adds an image based on given texture ID.

--- a/wrapper/DrawList.cpp
+++ b/wrapper/DrawList.cpp
@@ -105,7 +105,22 @@ void iggAddTriangleFilled(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 
    list->AddTriangleFilled(*p1Arg, *p2Arg, *p3Arg, col);
 }
 
+void iggAddImage(IggDrawList handle, IggTextureID textureID, IggVec2* pMin, IggVec2* pMax, IggVec2* uvMin, IggVec2* uvMax, IggPackedColor col) {
+  Vec2Wrapper pMinArg(pMin);
+  Vec2Wrapper pMaxArg(pMax);
+  Vec2Wrapper uvMinArg(uvMin);
+  Vec2Wrapper uvMaxArg(uvMax);
+
+  ImDrawList* list = reinterpret_cast<ImDrawList *>(handle);
+  list->AddImage(reinterpret_cast<ImTextureID>(textureID), *pMinArg, *pMaxArg, *uvMinArg, *uvMaxArg, col);
+}
+
 IggDrawList iggGetWindowDrawList()
 {
    return static_cast<IggDrawList>(const_cast<ImDrawList *>(ImGui::GetWindowDrawList()));
+}
+
+IggDrawList iggGetBackgroundDrawList()
+{
+   return static_cast<IggDrawList>(const_cast<ImDrawList *>(ImGui::GetBackgroundDrawList()));
 }

--- a/wrapper/DrawList.h
+++ b/wrapper/DrawList.h
@@ -21,8 +21,10 @@ extern void iggAddCircle(IggDrawList handle, IggVec2 const *center, float radius
 extern void iggAddCircleFilled(IggDrawList handle, IggVec2 const *center, float radius, IggPackedColor col, int numSegments);
 extern void iggAddTriangle(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 *p3, IggPackedColor col, float thickness);
 extern void iggAddTriangleFilled(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, IggVec2 *p3, IggPackedColor col);
+extern void iggAddImage(IggDrawList handle, IggTextureID textureID, IggVec2* pMin, IggVec2* pMax, IggVec2* uvMin, IggVec2* uvMax, IggPackedColor col);
 
 extern IggDrawList iggGetWindowDrawList();
+extern IggDrawList iggGetBackgroundDrawList();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- add AddImage and AddImage v methods for adding textures to draw lists
- add BackgroundDrawList function to access drawlist of the background behind all the windows.
Those functions make it easier to use imgui-go as a generic OpenGL canvas.