### PR TITLE
Constants given correct type.

### DIFF
--- a/Condition.go
+++ b/Condition.go
@@ -7,13 +7,13 @@ type Condition int
 
 const (
 	// ConditionNone sets no condition (always set the variable), same as ConditionAlways.
-	ConditionNone = 0
+	ConditionNone Condition = 0
 	// ConditionAlways sets the variable.
-	ConditionAlways Condition = 1 << 0
+	ConditionAlways Condition = 1 << iota
 	// ConditionOnce sets the variable once per runtime session (only the first call with succeed).
-	ConditionOnce = 1 << 1
+	ConditionOnce
 	// ConditionFirstUseEver sets the variable if the object/window has no persistently saved data (no entry in .ini file).
-	ConditionFirstUseEver = 1 << 2
+	ConditionFirstUseEver
 	// ConditionAppearing sets the variable if the object/window is appearing after being hidden/inactive (or the first time).
-	ConditionAppearing = 1 << 3
+	ConditionAppearing
 )

--- a/Condition.go
+++ b/Condition.go
@@ -9,11 +9,11 @@ const (
 	// ConditionNone sets no condition (always set the variable), same as ConditionAlways.
 	ConditionNone Condition = 0
 	// ConditionAlways sets the variable.
-	ConditionAlways Condition = 1 << iota
+	ConditionAlways Condition = 1 << 0
 	// ConditionOnce sets the variable once per runtime session (only the first call with succeed).
-	ConditionOnce
+	ConditionOnce Condition = 1 << 1
 	// ConditionFirstUseEver sets the variable if the object/window has no persistently saved data (no entry in .ini file).
-	ConditionFirstUseEver
+	ConditionFirstUseEver Condition = 1 << 2
 	// ConditionAppearing sets the variable if the object/window is appearing after being hidden/inactive (or the first time).
-	ConditionAppearing
+	ConditionAppearing Condition = 1 << 3
 )

--- a/DragDrop.go
+++ b/DragDrop.go
@@ -3,28 +3,27 @@ package imgui
 // #include "wrapper/DragDrop.h"
 import "C"
 
-// This is a list of BeginDragDropSource flags.
+// DragDropFlags for BeginDragDropSource(), etc.
+type DragDropFlags int
+
 const (
 	// DragDropFlagsNone specifies the default behaviour.
-	DragDropFlagsNone = 0
+	DragDropFlagsNone DragDropFlags = 0
 	// DragDropFlagsSourceNoPreviewTooltip hides the tooltip that is open so you can display a preview or description of the source contents.
-	DragDropFlagsSourceNoPreviewTooltip = 1 << 0
+	DragDropFlagsSourceNoPreviewTooltip DragDropFlags = 1 << 0
 	// DragDropFlagsSourceNoDisableHover preserves the behaviour of IsItemHovered. By default, when dragging we clear data so that IsItemHovered() will return true, to avoid subsequent user code submitting tooltips.
-	DragDropFlagsSourceNoDisableHover = 1 << 1
+	DragDropFlagsSourceNoDisableHover DragDropFlags = 1 << 1
 	// DragDropFlagsSourceNoHoldToOpenOthers disables the behavior that allows to open tree nodes and collapsing header by holding over them while dragging a source item.
-	DragDropFlagsSourceNoHoldToOpenOthers = 1 << 2
+	DragDropFlagsSourceNoHoldToOpenOthers DragDropFlags = 1 << 2
 	// DragDropFlagsSourceAllowNullID allows items such as Text(), Image() that have no unique identifier to be used as drag source, by manufacturing a temporary identifier based on their window-relative position. This is extremely unusual within the dear ecosystem and so we made it explicit.
-	DragDropFlagsSourceAllowNullID = 1 << 3
+	DragDropFlagsSourceAllowNullID DragDropFlags = 1 << 3
 	// DragDropFlagsSourceExtern specifies external source (from outside of), won't attempt to read current item/window info. Will always return true. Only one Extern source can be active simultaneously.
-	DragDropFlagsSourceExtern = 1 << 4
-)
+	DragDropFlagsSourceExtern DragDropFlags = 1 << 4
 
-// This is a list of AcceptDragDropPayload flags.
-const (
 	// DragDropFlagsAcceptBeforeDelivery makes AcceptDragDropPayload() return true even before the mouse button is released. You can then call IsDelivery() to test if the payload needs to be delivered.
-	DragDropFlagsAcceptBeforeDelivery = 1 << 10
+	DragDropFlagsAcceptBeforeDelivery DragDropFlags = 1 << 10
 	// DragDropFlagsAcceptNoDrawDefaultRect does not draw the default highlight rectangle when hovering over target.
-	DragDropFlagsAcceptNoDrawDefaultRect = 1 << 11
+	DragDropFlagsAcceptNoDrawDefaultRect DragDropFlags = 1 << 11
 	// DragDropFlagsAcceptPeekOnly is for peeking ahead and inspecting the payload before delivery.
 	DragDropFlagsAcceptPeekOnly = DragDropFlagsAcceptBeforeDelivery | DragDropFlagsAcceptNoDrawDefaultRect
 )
@@ -34,7 +33,7 @@ const (
 // a) call SetDragDropPayload() exactly once,
 // b) you may render the payload visual/description,
 // c) call EndDragDropSource().
-func BeginDragDropSource(flags int) bool {
+func BeginDragDropSource(flags DragDropFlags) bool {
 	return C.iggBeginDragDropSource(C.int(flags)) != 0
 }
 
@@ -63,7 +62,7 @@ func BeginDragDropTarget() bool {
 
 // AcceptDragDropPayload accepts contents of a given type.
 // If ImGuiDragDropFlags_AcceptBeforeDelivery is set you can peek into the payload before the mouse button is released.
-func AcceptDragDropPayload(dataType string, flags int) []byte {
+func AcceptDragDropPayload(dataType string, flags DragDropFlags) []byte {
 	typeArg, typeFin := wrapString(dataType)
 	defer typeFin()
 

--- a/DrawList.go
+++ b/DrawList.go
@@ -97,18 +97,30 @@ func BackgroundDrawList() DrawList {
 	return DrawList(C.iggGetBackgroundDrawList())
 }
 
-// This is a list of DrawCornerFlags.
+// DrawCornerFlags for DrawList.DrawRect(), etc.
+type DrawCornerFlags int
+
 const (
-	DrawCornerFlagsNone     = 0x0
-	DrawCornerFlagsTopLeft  = 0x1
-	DrawCornerFlagsTopRight = 0x2
-	DrawCornerFlagsBotLeft  = 0x4
-	DrawCornerFlagsBotRight = 0x8
-	DrawCornerFlagsTop      = DrawCornerFlagsTopLeft | DrawCornerFlagsTopRight
-	DrawCornerFlagsBot      = DrawCornerFlagsBotLeft | DrawCornerFlagsBotRight
-	DrawCornerFlagsLeft     = DrawCornerFlagsTopLeft | DrawCornerFlagsBotLeft
-	DrawCornerFlagsRight    = DrawCornerFlagsTopRight | DrawCornerFlagsBotRight
-	DrawCornerFlagsAll      = 0xF
+	// DrawCornerFlagsNone specifies the default behaviour.
+	DrawCornerFlagsNone DrawCornerFlags = 0
+	// DrawCornerFlagsTopLeft draw corner in the top left.
+	DrawCornerFlagsTopLeft DrawCornerFlags = 1 << 0
+	// DrawCornerFlagsTopRight draw corner in the top right.
+	DrawCornerFlagsTopRight DrawCornerFlags = 1 << 1
+	// DrawCornerFlagsBotLeft draw corner in the bottom left.
+	DrawCornerFlagsBotLeft DrawCornerFlags = 1 << 2
+	// DrawCornerFlagsBotRight draw corner in the bottom right.
+	DrawCornerFlagsBotRight DrawCornerFlags = 1 << 3
+	// DrawCornerFlagsTop draw corners at the top of the area.
+	DrawCornerFlagsTop DrawCornerFlags = DrawCornerFlagsTopLeft | DrawCornerFlagsTopRight
+	// DrawCornerFlagsBot draw corners at the bottom of the area.
+	DrawCornerFlagsBot DrawCornerFlags = DrawCornerFlagsBotLeft | DrawCornerFlagsBotRight
+	// DrawCornerFlagsLeft draw corners on the left of the area.
+	DrawCornerFlagsLeft DrawCornerFlags = DrawCornerFlagsTopLeft | DrawCornerFlagsBotLeft
+	// DrawCornerFlagsRight draw corners on the rigth of the area.
+	DrawCornerFlagsRight DrawCornerFlags = DrawCornerFlagsTopRight | DrawCornerFlagsBotRight
+	// DrawCornerFlagsAll draws all corners.
+	DrawCornerFlagsAll DrawCornerFlags = 0xF
 )
 
 // AddLine call AddLineV with a thickness value of 1.0.
@@ -133,10 +145,10 @@ func (list DrawList) AddRect(min Vec2, max Vec2, col PackedColor) {
 // 1 pixel are not rendered properly.
 //
 // drawCornerFlags indicate which corners of the rectangle are to be rounded.
-func (list DrawList) AddRectV(min Vec2, max Vec2, col PackedColor, rounding float32, drawCornerFlags int, thickness float32) {
+func (list DrawList) AddRectV(min Vec2, max Vec2, col PackedColor, rounding float32, flags DrawCornerFlags, thickness float32) {
 	minArg, _ := min.wrapped()
 	maxArg, _ := max.wrapped()
-	C.iggAddRect(list.handle(), minArg, maxArg, C.IggPackedColor(col), C.float(rounding), C.int(drawCornerFlags), C.float(thickness))
+	C.iggAddRect(list.handle(), minArg, maxArg, C.IggPackedColor(col), C.float(rounding), C.int(flags), C.float(thickness))
 }
 
 // AddRectFilled calls AddRectFilledV(min, max, col, 1.0, DrawCornerFlagsAll).
@@ -147,10 +159,10 @@ func (list DrawList) AddRectFilled(min Vec2, max Vec2, col PackedColor) {
 // AddRectFilledV adds a filled rectangle to the draw list. min is the
 // upper-left corner of the rectangle, and max is the lower right corner.
 // rectangles with dimensions of 1 pixel are not rendered properly.
-func (list DrawList) AddRectFilledV(min Vec2, max Vec2, col PackedColor, rounding float32, drawCornerFlags int) {
+func (list DrawList) AddRectFilledV(min Vec2, max Vec2, col PackedColor, rounding float32, flags DrawCornerFlags) {
 	minArg, _ := min.wrapped()
 	maxArg, _ := max.wrapped()
-	C.iggAddRectFilled(list.handle(), minArg, maxArg, C.IggPackedColor(col), C.float(rounding), C.int(drawCornerFlags))
+	C.iggAddRectFilled(list.handle(), minArg, maxArg, C.IggPackedColor(col), C.float(rounding), C.int(flags))
 }
 
 // AddCircleFilled calls AddCircleFilledV(center, radius, col, 0).

--- a/FreeType.go
+++ b/FreeType.go
@@ -14,7 +14,7 @@ import "C"
 // - The Default hinting mode usually looks good, but may distort glyphs in an unusual way.
 // - The Light hinting mode generates fuzzier glyphs but better matches Microsoft's rasterizer.
 // You can set those flags globaly in FontAtlas.SetFontBuilderFlags(flags)
-// You can set those flags on a per font basis in FontConfig.SetFontBuilderFlags(flags)
+// You can set those flags on a per font basis in FontConfig.SetFontBuilderFlags(flags).
 const (
 	// FreeTypeBuilderFlagsNoHinting disables hinting.
 	// This generally generates 'blurrier' bitmap glyphs when the glyph are rendered in any of the anti-aliased modes.

--- a/IO.go
+++ b/IO.go
@@ -232,7 +232,7 @@ func (io IO) SetIniFilename(value string) {
 type ConfigFlags int
 
 const (
-	// ConfigFlagsNone default = 0
+	// ConfigFlagsNone default = 0.
 	ConfigFlagsNone ConfigFlags = 0
 	// ConfigFlagsNavEnableKeyboard main keyboard navigation enable flag. NewFrame() will automatically fill
 	// io.NavInputs[] based on io.KeysDown[].
@@ -258,7 +258,7 @@ const (
 	ConfigFlagsNoMouseCursorChange ConfigFlags = 1 << 5
 
 	// User storage (to allow your back-end/engine to communicate to code that may be shared between multiple projects.
-	// Those flags are not used by core Dear ImGui)
+	// Those flags are not used by core Dear ImGui).
 
 	// ConfigFlagsIsSRGB application is SRGB-aware.
 	ConfigFlagsIsSRGB ConfigFlags = 1 << 20
@@ -275,7 +275,7 @@ func (io IO) SetConfigFlags(flags ConfigFlags) {
 type BackendFlags int
 
 const (
-	// BackendFlagsNone default = 0
+	// BackendFlagsNone default = 0.
 	BackendFlagsNone BackendFlags = 0
 	// BackendFlagsHasGamepad back-end Platform supports gamepad and currently has one connected.
 	BackendFlagsHasGamepad BackendFlags = 1 << 0

--- a/IO.go
+++ b/IO.go
@@ -271,24 +271,27 @@ func (io IO) SetConfigFlags(flags ConfigFlags) {
 	C.iggIoSetConfigFlags(io.handle, C.int(flags))
 }
 
+// BackendFlags for IO.SetBackendFlags.
+type BackendFlags int
+
 const (
-	// BackendFlagNone default = 0
-	BackendFlagNone = 0
-	// BackendFlagHasGamepad back-end Platform supports gamepad and currently has one connected.
-	BackendFlagHasGamepad = 1 << 0
-	// BackendFlagHasMouseCursors back-end Platform supports honoring GetMouseCursor() value to change the OS cursor
+	// BackendFlagsNone default = 0
+	BackendFlagsNone BackendFlags = 0
+	// BackendFlagsHasGamepad back-end Platform supports gamepad and currently has one connected.
+	BackendFlagsHasGamepad BackendFlags = 1 << 0
+	// BackendFlagsHasMouseCursors back-end Platform supports honoring GetMouseCursor() value to change the OS cursor
 	// shape.
-	BackendFlagHasMouseCursors = 1 << 1
-	// BackendFlagHasSetMousePos back-end Platform supports io.WantSetMousePos requests to reposition the OS mouse
+	BackendFlagsHasMouseCursors BackendFlags = 1 << 1
+	// BackendFlagsHasSetMousePos back-end Platform supports io.WantSetMousePos requests to reposition the OS mouse
 	// position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set).
-	BackendFlagHasSetMousePos = 1 << 2
+	BackendFlagsHasSetMousePos BackendFlags = 1 << 2
 	// BackendFlagsRendererHasVtxOffset back-end Renderer supports ImDrawCmd::VtxOffset. This enables output of large
 	// meshes (64K+ vertices) while still using 16-bits indices.
-	BackendFlagsRendererHasVtxOffset = 1 << 3
+	BackendFlagsRendererHasVtxOffset BackendFlags = 1 << 3
 )
 
 // SetBackendFlags sets back-end capabilities.
-func (io IO) SetBackendFlags(flags int) {
+func (io IO) SetBackendFlags(flags BackendFlags) {
 	C.iggIoSetBackendFlags(io.handle, C.int(flags))
 }
 

--- a/IO.go
+++ b/IO.go
@@ -228,43 +228,46 @@ func (io IO) SetIniFilename(value string) {
 	C.iggIoSetIniFilename(io.handle, valueArg)
 }
 
+// ConfigFlags for IO.SetConfigFlags.
+type ConfigFlags int
+
 const (
-	// ConfigFlagNone default = 0
-	ConfigFlagNone = 0
-	// ConfigFlagNavEnableKeyboard main keyboard navigation enable flag. NewFrame() will automatically fill
+	// ConfigFlagsNone default = 0
+	ConfigFlagsNone ConfigFlags = 0
+	// ConfigFlagsNavEnableKeyboard main keyboard navigation enable flag. NewFrame() will automatically fill
 	// io.NavInputs[] based on io.KeysDown[].
-	ConfigFlagNavEnableKeyboard = 1 << 0
-	// ConfigFlagNavEnableGamepad main gamepad navigation enable flag.
+	ConfigFlagsNavEnableKeyboard ConfigFlags = 1 << 0
+	// ConfigFlagsNavEnableGamepad main gamepad navigation enable flag.
 	// This is mostly to instruct your imgui back-end to fill io.NavInputs[]. Back-end also needs to set
 	// BackendFlagHasGamepad.
-	ConfigFlagNavEnableGamepad = 1 << 1
-	// ConfigFlagNavEnableSetMousePos instruct navigation to move the mouse cursor. May be useful on TV/console systems
+	ConfigFlagsNavEnableGamepad ConfigFlags = 1 << 1
+	// ConfigFlagsNavEnableSetMousePos instruct navigation to move the mouse cursor. May be useful on TV/console systems
 	// where moving a virtual mouse is awkward. Will update io.MousePos and set io.WantSetMousePos=true. If enabled you
 	// MUST honor io.WantSetMousePos requests in your binding, otherwise ImGui will react as if the mouse is jumping
 	// around back and forth.
-	ConfigFlagNavEnableSetMousePos = 1 << 2
-	// ConfigFlagNavNoCaptureKeyboard instruct navigation to not set the io.WantCaptureKeyboard flag when io.NavActive
+	ConfigFlagsNavEnableSetMousePos ConfigFlags = 1 << 2
+	// ConfigFlagsNavNoCaptureKeyboard instruct navigation to not set the io.WantCaptureKeyboard flag when io.NavActive
 	// is set.
-	ConfigFlagNavNoCaptureKeyboard = 1 << 3
-	// ConfigFlagNoMouse instruct imgui to clear mouse position/buttons in NewFrame(). This allows ignoring the mouse
+	ConfigFlagsNavNoCaptureKeyboard ConfigFlags = 1 << 3
+	// ConfigFlagsNoMouse instruct imgui to clear mouse position/buttons in NewFrame(). This allows ignoring the mouse
 	// information set by the back-end.
-	ConfigFlagNoMouse = 1 << 4
-	// ConfigFlagNoMouseCursorChange instruct back-end to not alter mouse cursor shape and visibility. Use if the
+	ConfigFlagsNoMouse ConfigFlags = 1 << 4
+	// ConfigFlagsNoMouseCursorChange instruct back-end to not alter mouse cursor shape and visibility. Use if the
 	// back-end cursor changes are interfering with yours and you don't want to use SetMouseCursor() to change mouse
 	// cursor. You may want to honor requests from imgui by reading GetMouseCursor() yourself instead.
-	ConfigFlagNoMouseCursorChange = 1 << 5
+	ConfigFlagsNoMouseCursorChange ConfigFlags = 1 << 5
 
 	// User storage (to allow your back-end/engine to communicate to code that may be shared between multiple projects.
 	// Those flags are not used by core Dear ImGui)
 
-	// ConfigFlagIsSRGB application is SRGB-aware.
-	ConfigFlagIsSRGB = 1 << 20
-	// ConfigFlagIsTouchScreen application is using a touch screen instead of a mouse.
-	ConfigFlagIsTouchScreen = 1 << 21
+	// ConfigFlagsIsSRGB application is SRGB-aware.
+	ConfigFlagsIsSRGB ConfigFlags = 1 << 20
+	// ConfigFlagsIsTouchScreen application is using a touch screen instead of a mouse.
+	ConfigFlagsIsTouchScreen ConfigFlags = 1 << 21
 )
 
 // SetConfigFlags sets the gamepad/keyboard navigation options, etc.
-func (io IO) SetConfigFlags(flags int) {
+func (io IO) SetConfigFlags(flags ConfigFlags) {
 	C.iggIoSetConfigFlags(io.handle, C.int(flags))
 }
 

--- a/InputTextCallbackData.go
+++ b/InputTextCallbackData.go
@@ -82,13 +82,13 @@ type InputTextCallbackData struct {
 }
 
 // EventFlag returns one of the InputTextFlagsCallback* constants to indicate the nature of the callback.
-func (data InputTextCallbackData) EventFlag() int {
-	return int(C.iggInputTextCallbackDataGetEventFlag(data.handle))
+func (data InputTextCallbackData) EventFlag() InputTextFlags {
+	return InputTextFlags(C.iggInputTextCallbackDataGetEventFlag(data.handle))
 }
 
 // Flags returns the set of flags that the user originally passed to InputText.
-func (data InputTextCallbackData) Flags() int {
-	return int(C.iggInputTextCallbackDataGetFlags(data.handle)) & ^inputTextFlagsCallbackResize
+func (data InputTextCallbackData) Flags() InputTextFlags {
+	return InputTextFlags(C.iggInputTextCallbackDataGetFlags(data.handle)) & ^inputTextFlagsCallbackResize
 }
 
 // EventChar returns the current character input. Only valid during CharFilter callback.

--- a/Popup.go
+++ b/Popup.go
@@ -23,13 +23,13 @@ const (
 	// PopupFlagsMouseButtonMiddle For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle)
 	PopupFlagsMouseButtonMiddle PopupFlags = 2
 	// PopupFlagsNoOpenOverExistingPopup For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack
-	PopupFlagsNoOpenOverExistingPopup PopupFlags = 1 << (iota + 5)
+	PopupFlagsNoOpenOverExistingPopup PopupFlags = 1 << 5
 	// PopupFlagsNoOpenOverItems For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space
-	PopupFlagsNoOpenOverItems
+	PopupFlagsNoOpenOverItems PopupFlags = 1 << 6
 	// PopupFlagsAnyPopupID For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup.
-	PopupFlagsAnyPopupID
+	PopupFlagsAnyPopupID PopupFlags = 1 << 7
 	// PopupFlagsAnyPopupLevel For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level)
-	PopupFlagsAnyPopupLevel
+	PopupFlagsAnyPopupLevel PopupFlags = 1 << 8
 	// PopupFlagsAnyPopup for any usage.
 	PopupFlagsAnyPopup = PopupFlagsAnyPopupID | PopupFlagsAnyPopupLevel
 )

--- a/Popup.go
+++ b/Popup.go
@@ -16,19 +16,19 @@ type PopupFlags int
 const (
 	// PopupFlagsNone no popup flags apply.
 	PopupFlagsNone PopupFlags = 0
-	// PopupFlagsMouseButtonLeft For BeginPopupContext*(): open on Left Mouse release. Guaranteed to always be == 0 (same as ImGuiMouseButton_Left)
+	// PopupFlagsMouseButtonLeft For BeginPopupContext*(): open on Left Mouse release. Guaranteed to always be == 0 (same as ImGuiMouseButton_Left).
 	PopupFlagsMouseButtonLeft PopupFlags = 0
-	// PopupFlagsMouseButtonRight For BeginPopupContext*(): open on Right Mouse release. Guaranteed to always be == 1 (same as ImGuiMouseButton_Right)
+	// PopupFlagsMouseButtonRight For BeginPopupContext*(): open on Right Mouse release. Guaranteed to always be == 1 (same as ImGuiMouseButton_Right).
 	PopupFlagsMouseButtonRight PopupFlags = 1
-	// PopupFlagsMouseButtonMiddle For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle)
+	// PopupFlagsMouseButtonMiddle For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle).
 	PopupFlagsMouseButtonMiddle PopupFlags = 2
-	// PopupFlagsNoOpenOverExistingPopup For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack
+	// PopupFlagsNoOpenOverExistingPopup For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack.
 	PopupFlagsNoOpenOverExistingPopup PopupFlags = 1 << 5
-	// PopupFlagsNoOpenOverItems For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space
+	// PopupFlagsNoOpenOverItems For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space.
 	PopupFlagsNoOpenOverItems PopupFlags = 1 << 6
 	// PopupFlagsAnyPopupID For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup.
 	PopupFlagsAnyPopupID PopupFlags = 1 << 7
-	// PopupFlagsAnyPopupLevel For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level)
+	// PopupFlagsAnyPopupLevel For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level).
 	PopupFlagsAnyPopupLevel PopupFlags = 1 << 8
 	// PopupFlagsAnyPopup for any usage.
 	PopupFlagsAnyPopup = PopupFlagsAnyPopupID | PopupFlagsAnyPopupLevel

--- a/Popup.go
+++ b/Popup.go
@@ -15,21 +15,21 @@ type PopupFlags int
 
 const (
 	// PopupFlagsNone no popup flags apply.
-	PopupFlagsNone = 0
+	PopupFlagsNone PopupFlags = 0
 	// PopupFlagsMouseButtonLeft For BeginPopupContext*(): open on Left Mouse release. Guaranteed to always be == 0 (same as ImGuiMouseButton_Left)
-	PopupFlagsMouseButtonLeft = 0
+	PopupFlagsMouseButtonLeft PopupFlags = 0
 	// PopupFlagsMouseButtonRight For BeginPopupContext*(): open on Right Mouse release. Guaranteed to always be == 1 (same as ImGuiMouseButton_Right)
-	PopupFlagsMouseButtonRight = 1
+	PopupFlagsMouseButtonRight PopupFlags = 1
 	// PopupFlagsMouseButtonMiddle For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle)
-	PopupFlagsMouseButtonMiddle = 2
+	PopupFlagsMouseButtonMiddle PopupFlags = 2
 	// PopupFlagsNoOpenOverExistingPopup For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack
-	PopupFlagsNoOpenOverExistingPopup = 1 << 5
+	PopupFlagsNoOpenOverExistingPopup PopupFlags = 1 << (iota + 5)
 	// PopupFlagsNoOpenOverItems For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space
-	PopupFlagsNoOpenOverItems = 1 << 6
+	PopupFlagsNoOpenOverItems
 	// PopupFlagsAnyPopupID For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup.
-	PopupFlagsAnyPopupID = 1 << 7
+	PopupFlagsAnyPopupID
 	// PopupFlagsAnyPopupLevel For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level)
-	PopupFlagsAnyPopupLevel = 1 << 8
+	PopupFlagsAnyPopupLevel
 	// PopupFlagsAnyPopup for any usage.
 	PopupFlagsAnyPopup = PopupFlagsAnyPopupID | PopupFlagsAnyPopupLevel
 )

--- a/State.go
+++ b/State.go
@@ -229,43 +229,43 @@ func MousePos() Vec2 {
 	return value
 }
 
-// MouseCursor for SetMouseCursor().
+// MouseCursorID for SetMouseCursor().
 //
 // User code may request backend to display given cursor by calling SetMouseCursor(),
 // which is why we have some cursors that are marked unused here.
-type MouseCursor int
+type MouseCursorID int
 
 const (
 	// MouseCursorNone no mouse cursor.
-	MouseCursorNone MouseCursor = -1
+	MouseCursorNone MouseCursorID = -1
 	// MouseCursorArrow standard arrow mouse cursor.
-	MouseCursorArrow MouseCursor = 0
+	MouseCursorArrow MouseCursorID = 0
 	// MouseCursorTextInput when hovering over InputText, etc.
-	MouseCursorTextInput MouseCursor = 1
+	MouseCursorTextInput MouseCursorID = 1
 	// MouseCursorResizeAll (Unused by imgui functions).
-	MouseCursorResizeAll MouseCursor = 2
+	MouseCursorResizeAll MouseCursorID = 2
 	// MouseCursorResizeNS when hovering over an horizontal border.
-	MouseCursorResizeNS MouseCursor = 3
+	MouseCursorResizeNS MouseCursorID = 3
 	// MouseCursorResizeEW when hovering over a vertical border or a column.
-	MouseCursorResizeEW MouseCursor = 4
+	MouseCursorResizeEW MouseCursorID = 4
 	// MouseCursorResizeNESW when hovering over the bottom-left corner of a window.
-	MouseCursorResizeNESW MouseCursor = 5
+	MouseCursorResizeNESW MouseCursorID = 5
 	// MouseCursorResizeNWSE when hovering over the bottom-right corner of a window.
-	MouseCursorResizeNWSE MouseCursor = 6
+	MouseCursorResizeNWSE MouseCursorID = 6
 	// MouseCursorHand (Unused by imgui functions. Use for e.g. hyperlinks).
-	MouseCursorHand MouseCursor = 7
+	MouseCursorHand MouseCursorID = 7
 	// MouseCursorCount is the number of defined mouse cursors.
-	MouseCursorCount MouseCursor = 8
+	MouseCursorCount MouseCursorID = 8
 )
 
-// CurrentMouseCursor returns desired cursor type, reset in imgui.NewFrame(), this is updated during the frame.
+// MouseCursor returns desired cursor type, reset in imgui.NewFrame(), this is updated during the frame.
 // Valid before Render(). If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you.
-func CurrentMouseCursor() int {
+func MouseCursor() int {
 	return int(C.iggGetMouseCursor())
 }
 
 // SetMouseCursor sets desired cursor type.
-func SetMouseCursor(cursor MouseCursor) {
+func SetMouseCursor(cursor MouseCursorID) {
 	C.iggSetMouseCursor(C.int(cursor))
 }
 

--- a/State.go
+++ b/State.go
@@ -19,7 +19,7 @@ func IsItemClicked() bool {
 
 // IsItemHoveredV returns true if the last item is hovered.
 // (and usable, aka not blocked by a popup, etc.). See HoveredFlags for more options.
-func IsItemHoveredV(flags int) bool {
+func IsItemHoveredV(flags HoveredFlags) bool {
 	return C.iggIsItemHovered(C.int(flags)) != 0
 }
 
@@ -123,26 +123,29 @@ func IsWindowFocused() bool {
 	return IsWindowFocusedV(FocusedFlagsNone)
 }
 
+// HoveredFlags for IsWindowHoveredV(), etc.
+type HoveredFlags int
+
 // This is a list of HoveredFlags combinations.
 const (
 	// HoveredFlagsNone Return true if directly over the item/window, not obstructed by another window,
 	// not obstructed by an active popup or modal blocking inputs under them.
-	HoveredFlagsNone = 0
+	HoveredFlagsNone HoveredFlags = 0
 	// HoveredFlagsChildWindows IsWindowHovered() only: Return true if any children of the window is hovered.
-	HoveredFlagsChildWindows = 1 << 0
+	HoveredFlagsChildWindows HoveredFlags = 1 << 0
 	// HoveredFlagsRootWindow IsWindowHovered() only: Test from root window (top most parent of the current hierarchy).
-	HoveredFlagsRootWindow = 1 << 1
+	HoveredFlagsRootWindow HoveredFlags = 1 << 1
 	// HoveredFlagsAnyWindow IsWindowHovered() only: Return true if any window is hovered.
-	HoveredFlagsAnyWindow = 1 << 2
+	HoveredFlagsAnyWindow HoveredFlags = 1 << 2
 	// HoveredFlagsAllowWhenBlockedByPopup Return true even if a popup window is normally blocking access to this item/window.
-	HoveredFlagsAllowWhenBlockedByPopup = 1 << 3
+	HoveredFlagsAllowWhenBlockedByPopup HoveredFlags = 1 << 3
 	// HoveredFlagsAllowWhenBlockedByActiveItem Return true even if an active item is blocking access to this item/window.
 	// Useful for Drag and Drop patterns.
-	HoveredFlagsAllowWhenBlockedByActiveItem = 1 << 5
+	HoveredFlagsAllowWhenBlockedByActiveItem HoveredFlags = 1 << 5
 	// HoveredFlagsAllowWhenOverlapped Return true even if the position is overlapped by another window
-	HoveredFlagsAllowWhenOverlapped = 1 << 6
+	HoveredFlagsAllowWhenOverlapped HoveredFlags = 1 << 6
 	// HoveredFlagsAllowWhenDisabled Return true even if the item is disabled
-	HoveredFlagsAllowWhenDisabled = 1 << 7
+	HoveredFlagsAllowWhenDisabled HoveredFlags = 1 << 7
 
 	HoveredFlagsRectOnly            = HoveredFlagsAllowWhenBlockedByPopup | HoveredFlagsAllowWhenBlockedByActiveItem | HoveredFlagsAllowWhenOverlapped
 	HoveredFlagsRootAndChildWindows = HoveredFlagsRootWindow | HoveredFlagsChildWindows
@@ -151,7 +154,7 @@ const (
 // IsWindowHoveredV returns if current window is hovered (and typically: not blocked by a popup/modal).
 // See flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app,
 // you should use the 'io.WantCaptureMouse' boolean for that!
-func IsWindowHoveredV(flags int) bool {
+func IsWindowHoveredV(flags HoveredFlags) bool {
 	return C.iggIsWindowHovered(C.int(flags)) != 0
 }
 
@@ -226,39 +229,43 @@ func MousePos() Vec2 {
 	return value
 }
 
-// Enumeration for MouseCursor()
+// MouseCursor for SetMouseCursor().
+//
 // User code may request backend to display given cursor by calling SetMouseCursor(),
 // which is why we have some cursors that are marked unused here.
+type MouseCursor int
+
 const (
 	// MouseCursorNone no mouse cursor
-	MouseCursorNone = -1
+	MouseCursorNone MouseCursor = -1
 	// MouseCursorArrow standard arrow mouse cursor
-	MouseCursorArrow = 0
+	MouseCursorArrow MouseCursor = 0
 	// MouseCursorTextInput when hovering over InputText, etc.
-	MouseCursorTextInput = 1
+	MouseCursorTextInput MouseCursor = 1
 	// MouseCursorResizeAll (Unused by imgui functions)
-	MouseCursorResizeAll = 2
+	MouseCursorResizeAll MouseCursor = 2
 	// MouseCursorResizeNS when hovering over an horizontal border
-	MouseCursorResizeNS = 3
+	MouseCursorResizeNS MouseCursor = 3
 	// MouseCursorResizeEW when hovering over a vertical border or a column
-	MouseCursorResizeEW = 4
+	MouseCursorResizeEW MouseCursor = 4
 	// MouseCursorResizeNESW when hovering over the bottom-left corner of a window
-	MouseCursorResizeNESW = 5
+	MouseCursorResizeNESW MouseCursor = 5
 	// MouseCursorResizeNWSE when hovering over the bottom-right corner of a window
-	MouseCursorResizeNWSE = 6
+	MouseCursorResizeNWSE MouseCursor = 6
 	// MouseCursorHand (Unused by imgui functions. Use for e.g. hyperlinks)
-	MouseCursorHand  = 7
-	MouseCursorCount = 8
+	MouseCursorHand MouseCursor = 7
+	// MouseCursorCount is the number of defined mouse cursors
+	MouseCursorCount MouseCursor = 8
 )
 
-// MouseCursor returns desired cursor type, reset in imgui.NewFrame(), this is updated during the frame.
+// CurrentMouseCursor returns desired cursor type, reset in imgui.NewFrame(), this is updated during the frame.
 // Valid before Render(). If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you.
-func MouseCursor() int {
+func CurrentMouseCursor() int {
 	return int(C.iggGetMouseCursor())
 }
 
 // SetMouseCursor sets desired cursor type.
-func SetMouseCursor(cursor int) {
+func SetMouseCursor(cursor MouseCursor) {
 	C.iggSetMouseCursor(C.int(cursor))
 }
 

--- a/State.go
+++ b/State.go
@@ -101,9 +101,9 @@ const (
 	// FocusedFlagsNone Return true if directly over the item/window, not obstructed by another window,
 	// not obstructed by an active popup or modal blocking inputs under them.
 	FocusedFlagsNone FocusedFlags = 0
-	// FocusedFlagsChildWindows returns true if any children of the window is focused
+	// FocusedFlagsChildWindows returns true if any children of the window is focused.
 	FocusedFlagsChildWindows FocusedFlags = 1 << 0
-	// FocusedFlagsRootWindow tests from root window (top most parent of the current hierarchy)
+	// FocusedFlagsRootWindow tests from root window (top most parent of the current hierarchy).
 	FocusedFlagsRootWindow FocusedFlags = 1 << 1
 	// FocusedFlagsAnyWindow returns true if any window is focused.
 	// Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this.
@@ -142,9 +142,9 @@ const (
 	// HoveredFlagsAllowWhenBlockedByActiveItem Return true even if an active item is blocking access to this item/window.
 	// Useful for Drag and Drop patterns.
 	HoveredFlagsAllowWhenBlockedByActiveItem HoveredFlags = 1 << 5
-	// HoveredFlagsAllowWhenOverlapped Return true even if the position is overlapped by another window
+	// HoveredFlagsAllowWhenOverlapped Return true even if the position is overlapped by another window.
 	HoveredFlagsAllowWhenOverlapped HoveredFlags = 1 << 6
-	// HoveredFlagsAllowWhenDisabled Return true even if the item is disabled
+	// HoveredFlagsAllowWhenDisabled Return true even if the item is disabled.
 	HoveredFlagsAllowWhenDisabled HoveredFlags = 1 << 7
 
 	HoveredFlagsRectOnly            = HoveredFlagsAllowWhenBlockedByPopup | HoveredFlagsAllowWhenBlockedByActiveItem | HoveredFlagsAllowWhenOverlapped
@@ -236,25 +236,25 @@ func MousePos() Vec2 {
 type MouseCursor int
 
 const (
-	// MouseCursorNone no mouse cursor
+	// MouseCursorNone no mouse cursor.
 	MouseCursorNone MouseCursor = -1
-	// MouseCursorArrow standard arrow mouse cursor
+	// MouseCursorArrow standard arrow mouse cursor.
 	MouseCursorArrow MouseCursor = 0
 	// MouseCursorTextInput when hovering over InputText, etc.
 	MouseCursorTextInput MouseCursor = 1
-	// MouseCursorResizeAll (Unused by imgui functions)
+	// MouseCursorResizeAll (Unused by imgui functions).
 	MouseCursorResizeAll MouseCursor = 2
-	// MouseCursorResizeNS when hovering over an horizontal border
+	// MouseCursorResizeNS when hovering over an horizontal border.
 	MouseCursorResizeNS MouseCursor = 3
-	// MouseCursorResizeEW when hovering over a vertical border or a column
+	// MouseCursorResizeEW when hovering over a vertical border or a column.
 	MouseCursorResizeEW MouseCursor = 4
-	// MouseCursorResizeNESW when hovering over the bottom-left corner of a window
+	// MouseCursorResizeNESW when hovering over the bottom-left corner of a window.
 	MouseCursorResizeNESW MouseCursor = 5
-	// MouseCursorResizeNWSE when hovering over the bottom-right corner of a window
+	// MouseCursorResizeNWSE when hovering over the bottom-right corner of a window.
 	MouseCursorResizeNWSE MouseCursor = 6
-	// MouseCursorHand (Unused by imgui functions. Use for e.g. hyperlinks)
+	// MouseCursorHand (Unused by imgui functions. Use for e.g. hyperlinks).
 	MouseCursorHand MouseCursor = 7
-	// MouseCursorCount is the number of defined mouse cursors
+	// MouseCursorCount is the number of defined mouse cursors.
 	MouseCursorCount MouseCursor = 8
 )
 

--- a/State.go
+++ b/State.go
@@ -93,25 +93,28 @@ func IsWindowCollapsed() bool {
 	return C.iggIsWindowCollapsed() != 0
 }
 
+// FocusedFlags for IsWindowFocusedV().
+type FocusedFlags int
+
 // This is a list of FocusedFlags combinations.
 const (
 	// FocusedFlagsNone Return true if directly over the item/window, not obstructed by another window,
 	// not obstructed by an active popup or modal blocking inputs under them.
-	FocusedFlagsNone = 0
+	FocusedFlagsNone FocusedFlags = 0
 	// FocusedFlagsChildWindows returns true if any children of the window is focused
-	FocusedFlagsChildWindows = 1 << 0
+	FocusedFlagsChildWindows FocusedFlags = 1 << 0
 	// FocusedFlagsRootWindow tests from root window (top most parent of the current hierarchy)
-	FocusedFlagsRootWindow = 1 << 1
+	FocusedFlagsRootWindow FocusedFlags = 1 << 1
 	// FocusedFlagsAnyWindow returns true if any window is focused.
 	// Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this.
 	// Use WantCaptureMouse instead.
-	FocusedFlagsAnyWindow = 1 << 2
+	FocusedFlagsAnyWindow FocusedFlags = 1 << 2
 
 	FocusedFlagsRootAndChildWindows = FocusedFlagsRootWindow | FocusedFlagsChildWindows
 )
 
 // IsWindowFocusedV returns if current window is focused or its root/child, depending on flags. See flags for options.
-func IsWindowFocusedV(flags int) bool {
+func IsWindowFocusedV(flags FocusedFlags) bool {
 	return C.iggIsWindowFocused(C.int(flags)) != 0
 }
 

--- a/Style.go
+++ b/Style.go
@@ -7,53 +7,53 @@ import "C"
 type StyleVar int
 
 const (
-	// StyleVarAlpha is a float
+	// StyleVarAlpha is a float.
 	StyleVarAlpha StyleVar = 0
-	// StyleVarWindowPadding is a Vec2
+	// StyleVarWindowPadding is a Vec2.
 	StyleVarWindowPadding StyleVar = 1
-	// StyleVarWindowRounding is a float
+	// StyleVarWindowRounding is a float.
 	StyleVarWindowRounding StyleVar = 2
-	// StyleVarWindowBorderSize is a float
+	// StyleVarWindowBorderSize is a float.
 	StyleVarWindowBorderSize StyleVar = 3
-	// StyleVarWindowMinSize is a Vec2
+	// StyleVarWindowMinSize is a Vec2.
 	StyleVarWindowMinSize StyleVar = 4
-	// StyleVarWindowTitleAlign is a Vec2
+	// StyleVarWindowTitleAlign is a Vec2.
 	StyleVarWindowTitleAlign StyleVar = 5
-	// StyleVarChildRounding is a float
+	// StyleVarChildRounding is a float.
 	StyleVarChildRounding StyleVar = 6
-	// StyleVarChildBorderSize is a float
+	// StyleVarChildBorderSize is a float.
 	StyleVarChildBorderSize StyleVar = 7
-	// StyleVarPopupRounding is a float
+	// StyleVarPopupRounding is a float.
 	StyleVarPopupRounding StyleVar = 8
-	// StyleVarPopupBorderSize is a float
+	// StyleVarPopupBorderSize is a float.
 	StyleVarPopupBorderSize StyleVar = 9
-	// StyleVarFramePadding is a Vec2
+	// StyleVarFramePadding is a Vec2.
 	StyleVarFramePadding StyleVar = 10
-	// StyleVarFrameRounding is a float
+	// StyleVarFrameRounding is a float.
 	StyleVarFrameRounding StyleVar = 11
-	// StyleVarFrameBorderSize is a float
+	// StyleVarFrameBorderSize is a float.
 	StyleVarFrameBorderSize StyleVar = 12
-	// StyleVarItemSpacing is a Vec2
+	// StyleVarItemSpacing is a Vec2.
 	StyleVarItemSpacing StyleVar = 13
-	// StyleVarItemInnerSpacing is a Vec2
+	// StyleVarItemInnerSpacing is a Vec2.
 	StyleVarItemInnerSpacing StyleVar = 14
-	// StyleVarIndentSpacing is a float
+	// StyleVarIndentSpacing is a float.
 	StyleVarIndentSpacing StyleVar = 15
-	// StyleVarCellPadding is a Vec2
+	// StyleVarCellPadding is a Vec2.
 	StyleVarCellPadding StyleVar = 16
-	// StyleVarScrollbarSize is a float
+	// StyleVarScrollbarSize is a float.
 	StyleVarScrollbarSize StyleVar = 17
-	// StyleVarScrollbarRounding is a float
+	// StyleVarScrollbarRounding is a float.
 	StyleVarScrollbarRounding StyleVar = 18
-	// StyleVarGrabMinSize is a float
+	// StyleVarGrabMinSize is a float.
 	StyleVarGrabMinSize StyleVar = 19
-	// StyleVarGrabRounding is a float
+	// StyleVarGrabRounding is a float.
 	StyleVarGrabRounding StyleVar = 20
-	// StyleVarTabRounding is a float
+	// StyleVarTabRounding is a float.
 	StyleVarTabRounding StyleVar = 21
-	// StyleVarButtonTextAlign is a Vec2
+	// StyleVarButtonTextAlign is a Vec2.
 	StyleVarButtonTextAlign StyleVar = 22
-	// StyleVarSelectableTextAlign is a Vec2
+	// StyleVarSelectableTextAlign is a Vec2.
 	StyleVarSelectableTextAlign StyleVar = 23
 )
 

--- a/Style.go
+++ b/Style.go
@@ -3,118 +3,118 @@ package imgui
 // #include "wrapper/Style.h"
 import "C"
 
-// StyleVar identifies a style variable in the UI style.
-type StyleVar int
+// StyleVarID identifies a style variable in the UI style.
+type StyleVarID int
 
 const (
 	// StyleVarAlpha is a float.
-	StyleVarAlpha StyleVar = 0
+	StyleVarAlpha StyleVarID = 0
 	// StyleVarWindowPadding is a Vec2.
-	StyleVarWindowPadding StyleVar = 1
+	StyleVarWindowPadding StyleVarID = 1
 	// StyleVarWindowRounding is a float.
-	StyleVarWindowRounding StyleVar = 2
+	StyleVarWindowRounding StyleVarID = 2
 	// StyleVarWindowBorderSize is a float.
-	StyleVarWindowBorderSize StyleVar = 3
+	StyleVarWindowBorderSize StyleVarID = 3
 	// StyleVarWindowMinSize is a Vec2.
-	StyleVarWindowMinSize StyleVar = 4
+	StyleVarWindowMinSize StyleVarID = 4
 	// StyleVarWindowTitleAlign is a Vec2.
-	StyleVarWindowTitleAlign StyleVar = 5
+	StyleVarWindowTitleAlign StyleVarID = 5
 	// StyleVarChildRounding is a float.
-	StyleVarChildRounding StyleVar = 6
+	StyleVarChildRounding StyleVarID = 6
 	// StyleVarChildBorderSize is a float.
-	StyleVarChildBorderSize StyleVar = 7
+	StyleVarChildBorderSize StyleVarID = 7
 	// StyleVarPopupRounding is a float.
-	StyleVarPopupRounding StyleVar = 8
+	StyleVarPopupRounding StyleVarID = 8
 	// StyleVarPopupBorderSize is a float.
-	StyleVarPopupBorderSize StyleVar = 9
+	StyleVarPopupBorderSize StyleVarID = 9
 	// StyleVarFramePadding is a Vec2.
-	StyleVarFramePadding StyleVar = 10
+	StyleVarFramePadding StyleVarID = 10
 	// StyleVarFrameRounding is a float.
-	StyleVarFrameRounding StyleVar = 11
+	StyleVarFrameRounding StyleVarID = 11
 	// StyleVarFrameBorderSize is a float.
-	StyleVarFrameBorderSize StyleVar = 12
+	StyleVarFrameBorderSize StyleVarID = 12
 	// StyleVarItemSpacing is a Vec2.
-	StyleVarItemSpacing StyleVar = 13
+	StyleVarItemSpacing StyleVarID = 13
 	// StyleVarItemInnerSpacing is a Vec2.
-	StyleVarItemInnerSpacing StyleVar = 14
+	StyleVarItemInnerSpacing StyleVarID = 14
 	// StyleVarIndentSpacing is a float.
-	StyleVarIndentSpacing StyleVar = 15
+	StyleVarIndentSpacing StyleVarID = 15
 	// StyleVarCellPadding is a Vec2.
-	StyleVarCellPadding StyleVar = 16
+	StyleVarCellPadding StyleVarID = 16
 	// StyleVarScrollbarSize is a float.
-	StyleVarScrollbarSize StyleVar = 17
+	StyleVarScrollbarSize StyleVarID = 17
 	// StyleVarScrollbarRounding is a float.
-	StyleVarScrollbarRounding StyleVar = 18
+	StyleVarScrollbarRounding StyleVarID = 18
 	// StyleVarGrabMinSize is a float.
-	StyleVarGrabMinSize StyleVar = 19
+	StyleVarGrabMinSize StyleVarID = 19
 	// StyleVarGrabRounding is a float.
-	StyleVarGrabRounding StyleVar = 20
+	StyleVarGrabRounding StyleVarID = 20
 	// StyleVarTabRounding is a float.
-	StyleVarTabRounding StyleVar = 21
+	StyleVarTabRounding StyleVarID = 21
 	// StyleVarButtonTextAlign is a Vec2.
-	StyleVarButtonTextAlign StyleVar = 22
+	StyleVarButtonTextAlign StyleVarID = 22
 	// StyleVarSelectableTextAlign is a Vec2.
-	StyleVarSelectableTextAlign StyleVar = 23
+	StyleVarSelectableTextAlign StyleVarID = 23
 )
 
-// StyleColor identifies a color in the UI style.
-type StyleColor int
+// StyleColorID identifies a color in the UI style.
+type StyleColorID int
 
 // This is the list of StyleColor identifier.
 const (
-	StyleColorText                  StyleColor = 0
-	StyleColorTextDisabled          StyleColor = 1
-	StyleColorWindowBg              StyleColor = 2
-	StyleColorChildBg               StyleColor = 3
-	StyleColorPopupBg               StyleColor = 4
-	StyleColorBorder                StyleColor = 5
-	StyleColorBorderShadow          StyleColor = 6
-	StyleColorFrameBg               StyleColor = 7
-	StyleColorFrameBgHovered        StyleColor = 8
-	StyleColorFrameBgActive         StyleColor = 9
-	StyleColorTitleBg               StyleColor = 10
-	StyleColorTitleBgActive         StyleColor = 11
-	StyleColorTitleBgCollapsed      StyleColor = 12
-	StyleColorMenuBarBg             StyleColor = 13
-	StyleColorScrollbarBg           StyleColor = 14
-	StyleColorScrollbarGrab         StyleColor = 15
-	StyleColorScrollbarGrabHovered  StyleColor = 16
-	StyleColorScrollbarGrabActive   StyleColor = 17
-	StyleColorCheckMark             StyleColor = 18
-	StyleColorSliderGrab            StyleColor = 19
-	StyleColorSliderGrabActive      StyleColor = 20
-	StyleColorButton                StyleColor = 21
-	StyleColorButtonHovered         StyleColor = 22
-	StyleColorButtonActive          StyleColor = 23
-	StyleColorHeader                StyleColor = 24
-	StyleColorHeaderHovered         StyleColor = 25
-	StyleColorHeaderActive          StyleColor = 26
-	StyleColorSeparator             StyleColor = 27
-	StyleColorSeparatorHovered      StyleColor = 28
-	StyleColorSeparatorActive       StyleColor = 29
-	StyleColorResizeGrip            StyleColor = 30
-	StyleColorResizeGripHovered     StyleColor = 31
-	StyleColorResizeGripActive      StyleColor = 32
-	StyleColorTab                   StyleColor = 33
-	StyleColorTabHovered            StyleColor = 34
-	StyleColorTabActive             StyleColor = 35
-	StyleColorTabUnfocused          StyleColor = 36
-	StyleColorTabUnfocusedActive    StyleColor = 37
-	StyleColorPlotLines             StyleColor = 38
-	StyleColorPlotLinesHovered      StyleColor = 39
-	StyleColorPlotHistogram         StyleColor = 40
-	StyleColorPlotHistogramHovered  StyleColor = 41
-	StyleColorTableHeaderBg         StyleColor = 42 // Table header background
-	StyleColorTableBorderStrong     StyleColor = 43 // Table outer and header borders (prefer using Alpha=1.0 here)
-	StyleColorTableBorderLight      StyleColor = 44 // Table inner borders (prefer using Alpha=1.0 here)
-	StyleColorTableRowBg            StyleColor = 45 // Table row background (even rows)
-	StyleColorTableRowBgAlt         StyleColor = 46 // Table row background (odd rows)
-	StyleColorTextSelectedBg        StyleColor = 47
-	StyleColorDragDropTarget        StyleColor = 48
-	StyleColorNavHighlight          StyleColor = 49 // Gamepad/keyboard: current highlighted item
-	StyleColorNavWindowingHighlight StyleColor = 50 // Highlight window when using CTRL+TAB
-	StyleColorNavWindowingDarkening StyleColor = 51 // Darken/colorize entire screen behind the CTRL+TAB window list, when active
-	StyleColorModalWindowDarkening  StyleColor = 52 // Darken/colorize entire screen behind a modal window, when one is active
+	StyleColorText                  StyleColorID = 0
+	StyleColorTextDisabled          StyleColorID = 1
+	StyleColorWindowBg              StyleColorID = 2
+	StyleColorChildBg               StyleColorID = 3
+	StyleColorPopupBg               StyleColorID = 4
+	StyleColorBorder                StyleColorID = 5
+	StyleColorBorderShadow          StyleColorID = 6
+	StyleColorFrameBg               StyleColorID = 7
+	StyleColorFrameBgHovered        StyleColorID = 8
+	StyleColorFrameBgActive         StyleColorID = 9
+	StyleColorTitleBg               StyleColorID = 10
+	StyleColorTitleBgActive         StyleColorID = 11
+	StyleColorTitleBgCollapsed      StyleColorID = 12
+	StyleColorMenuBarBg             StyleColorID = 13
+	StyleColorScrollbarBg           StyleColorID = 14
+	StyleColorScrollbarGrab         StyleColorID = 15
+	StyleColorScrollbarGrabHovered  StyleColorID = 16
+	StyleColorScrollbarGrabActive   StyleColorID = 17
+	StyleColorCheckMark             StyleColorID = 18
+	StyleColorSliderGrab            StyleColorID = 19
+	StyleColorSliderGrabActive      StyleColorID = 20
+	StyleColorButton                StyleColorID = 21
+	StyleColorButtonHovered         StyleColorID = 22
+	StyleColorButtonActive          StyleColorID = 23
+	StyleColorHeader                StyleColorID = 24
+	StyleColorHeaderHovered         StyleColorID = 25
+	StyleColorHeaderActive          StyleColorID = 26
+	StyleColorSeparator             StyleColorID = 27
+	StyleColorSeparatorHovered      StyleColorID = 28
+	StyleColorSeparatorActive       StyleColorID = 29
+	StyleColorResizeGrip            StyleColorID = 30
+	StyleColorResizeGripHovered     StyleColorID = 31
+	StyleColorResizeGripActive      StyleColorID = 32
+	StyleColorTab                   StyleColorID = 33
+	StyleColorTabHovered            StyleColorID = 34
+	StyleColorTabActive             StyleColorID = 35
+	StyleColorTabUnfocused          StyleColorID = 36
+	StyleColorTabUnfocusedActive    StyleColorID = 37
+	StyleColorPlotLines             StyleColorID = 38
+	StyleColorPlotLinesHovered      StyleColorID = 39
+	StyleColorPlotHistogram         StyleColorID = 40
+	StyleColorPlotHistogramHovered  StyleColorID = 41
+	StyleColorTableHeaderBg         StyleColorID = 42 // Table header background
+	StyleColorTableBorderStrong     StyleColorID = 43 // Table outer and header borders (prefer using Alpha=1.0 here)
+	StyleColorTableBorderLight      StyleColorID = 44 // Table inner borders (prefer using Alpha=1.0 here)
+	StyleColorTableRowBg            StyleColorID = 45 // Table row background (even rows)
+	StyleColorTableRowBgAlt         StyleColorID = 46 // Table row background (odd rows)
+	StyleColorTextSelectedBg        StyleColorID = 47
+	StyleColorDragDropTarget        StyleColorID = 48
+	StyleColorNavHighlight          StyleColorID = 49 // Gamepad/keyboard: current highlighted item
+	StyleColorNavWindowingHighlight StyleColorID = 50 // Highlight window when using CTRL+TAB
+	StyleColorNavWindowingDarkening StyleColorID = 51 // Darken/colorize entire screen behind the CTRL+TAB window list, when active
+	StyleColorModalWindowDarkening  StyleColorID = 52 // Darken/colorize entire screen behind a modal window, when one is active
 )
 
 // Style describes the overall graphical representation of the user interface.
@@ -142,7 +142,7 @@ func StyleColorsLight() {
 
 // PushStyleColor pushes the current style color for given ID on a stack and sets the given one.
 // To revert to the previous color, call PopStyleColor().
-func PushStyleColor(id StyleColor, color Vec4) {
+func PushStyleColor(id StyleColorID, color Vec4) {
 	colorArg, _ := color.wrapped()
 	C.iggPushStyleColor(C.int(id), colorArg)
 }
@@ -158,12 +158,12 @@ func PopStyleColor() {
 }
 
 // PushStyleVarFloat pushes a float value on the stack to temporarily modify a style variable.
-func PushStyleVarFloat(id StyleVar, value float32) {
+func PushStyleVarFloat(id StyleVarID, value float32) {
 	C.iggPushStyleVarFloat(C.int(id), C.float(value))
 }
 
 // PushStyleVarVec2 pushes a Vec2 value on the stack to temporarily modify a style variable.
-func PushStyleVarVec2(id StyleVar, value Vec2) {
+func PushStyleVarVec2(id StyleVarID, value Vec2) {
 	valueArg, _ := value.wrapped()
 	C.iggPushStyleVarVec2(C.int(id), valueArg)
 }
@@ -229,13 +229,13 @@ func (style Style) CellPadding() Vec2 {
 }
 
 // SetColor sets a color value of the UI style.
-func (style Style) SetColor(id StyleColor, value Vec4) {
+func (style Style) SetColor(id StyleColorID, value Vec4) {
 	valueArg, _ := value.wrapped()
 	C.iggStyleSetColor(style.handle(), C.int(id), valueArg)
 }
 
 // Color gets a color value from the UI style.
-func (style Style) Color(id StyleColor) Vec4 {
+func (style Style) Color(id StyleColorID) Vec4 {
 	var value Vec4
 	valueArg, valueFin := value.wrapped()
 	C.iggStyleGetColor(style.handle(), C.int(id), valueArg)

--- a/Style.go
+++ b/Style.go
@@ -3,118 +3,118 @@ package imgui
 // #include "wrapper/Style.h"
 import "C"
 
-// StyleVarID identifies a style variable in the UI style.
-type StyleVarID int
-
-// StyleColorID identifies a color in the UI style.
-type StyleColorID int
+// StyleVar identifies a style variable in the UI style.
+type StyleVar int
 
 const (
 	// StyleVarAlpha is a float
-	StyleVarAlpha StyleVarID = 0
+	StyleVarAlpha StyleVar = 0
 	// StyleVarWindowPadding is a Vec2
-	StyleVarWindowPadding StyleVarID = 1
+	StyleVarWindowPadding StyleVar = 1
 	// StyleVarWindowRounding is a float
-	StyleVarWindowRounding StyleVarID = 2
+	StyleVarWindowRounding StyleVar = 2
 	// StyleVarWindowBorderSize is a float
-	StyleVarWindowBorderSize StyleVarID = 3
+	StyleVarWindowBorderSize StyleVar = 3
 	// StyleVarWindowMinSize is a Vec2
-	StyleVarWindowMinSize StyleVarID = 4
+	StyleVarWindowMinSize StyleVar = 4
 	// StyleVarWindowTitleAlign is a Vec2
-	StyleVarWindowTitleAlign StyleVarID = 5
+	StyleVarWindowTitleAlign StyleVar = 5
 	// StyleVarChildRounding is a float
-	StyleVarChildRounding StyleVarID = 6
+	StyleVarChildRounding StyleVar = 6
 	// StyleVarChildBorderSize is a float
-	StyleVarChildBorderSize StyleVarID = 7
+	StyleVarChildBorderSize StyleVar = 7
 	// StyleVarPopupRounding is a float
-	StyleVarPopupRounding StyleVarID = 8
+	StyleVarPopupRounding StyleVar = 8
 	// StyleVarPopupBorderSize is a float
-	StyleVarPopupBorderSize StyleVarID = 9
+	StyleVarPopupBorderSize StyleVar = 9
 	// StyleVarFramePadding is a Vec2
-	StyleVarFramePadding StyleVarID = 10
+	StyleVarFramePadding StyleVar = 10
 	// StyleVarFrameRounding is a float
-	StyleVarFrameRounding StyleVarID = 11
+	StyleVarFrameRounding StyleVar = 11
 	// StyleVarFrameBorderSize is a float
-	StyleVarFrameBorderSize StyleVarID = 12
+	StyleVarFrameBorderSize StyleVar = 12
 	// StyleVarItemSpacing is a Vec2
-	StyleVarItemSpacing StyleVarID = 13
+	StyleVarItemSpacing StyleVar = 13
 	// StyleVarItemInnerSpacing is a Vec2
-	StyleVarItemInnerSpacing StyleVarID = 14
+	StyleVarItemInnerSpacing StyleVar = 14
 	// StyleVarIndentSpacing is a float
-	StyleVarIndentSpacing StyleVarID = 15
+	StyleVarIndentSpacing StyleVar = 15
 	// StyleVarCellPadding is a Vec2
-	StyleVarCellPadding StyleVarID = 16
+	StyleVarCellPadding StyleVar = 16
 	// StyleVarScrollbarSize is a float
-	StyleVarScrollbarSize StyleVarID = 17
+	StyleVarScrollbarSize StyleVar = 17
 	// StyleVarScrollbarRounding is a float
-	StyleVarScrollbarRounding StyleVarID = 18
+	StyleVarScrollbarRounding StyleVar = 18
 	// StyleVarGrabMinSize is a float
-	StyleVarGrabMinSize StyleVarID = 19
+	StyleVarGrabMinSize StyleVar = 19
 	// StyleVarGrabRounding is a float
-	StyleVarGrabRounding StyleVarID = 20
+	StyleVarGrabRounding StyleVar = 20
 	// StyleVarTabRounding is a float
-	StyleVarTabRounding StyleVarID = 21
+	StyleVarTabRounding StyleVar = 21
 	// StyleVarButtonTextAlign is a Vec2
-	StyleVarButtonTextAlign StyleVarID = 22
+	StyleVarButtonTextAlign StyleVar = 22
 	// StyleVarSelectableTextAlign is a Vec2
-	StyleVarSelectableTextAlign StyleVarID = 23
+	StyleVarSelectableTextAlign StyleVar = 23
 )
+
+// StyleColor identifies a color in the UI style.
+type StyleColor int
 
 // This is the list of StyleColor identifier.
 const (
-	StyleColorText                  StyleColorID = 0
-	StyleColorTextDisabled          StyleColorID = 1
-	StyleColorWindowBg              StyleColorID = 2
-	StyleColorChildBg               StyleColorID = 3
-	StyleColorPopupBg               StyleColorID = 4
-	StyleColorBorder                StyleColorID = 5
-	StyleColorBorderShadow          StyleColorID = 6
-	StyleColorFrameBg               StyleColorID = 7
-	StyleColorFrameBgHovered        StyleColorID = 8
-	StyleColorFrameBgActive         StyleColorID = 9
-	StyleColorTitleBg               StyleColorID = 10
-	StyleColorTitleBgActive         StyleColorID = 11
-	StyleColorTitleBgCollapsed      StyleColorID = 12
-	StyleColorMenuBarBg             StyleColorID = 13
-	StyleColorScrollbarBg           StyleColorID = 14
-	StyleColorScrollbarGrab         StyleColorID = 15
-	StyleColorScrollbarGrabHovered  StyleColorID = 16
-	StyleColorScrollbarGrabActive   StyleColorID = 17
-	StyleColorCheckMark             StyleColorID = 18
-	StyleColorSliderGrab            StyleColorID = 19
-	StyleColorSliderGrabActive      StyleColorID = 20
-	StyleColorButton                StyleColorID = 21
-	StyleColorButtonHovered         StyleColorID = 22
-	StyleColorButtonActive          StyleColorID = 23
-	StyleColorHeader                StyleColorID = 24
-	StyleColorHeaderHovered         StyleColorID = 25
-	StyleColorHeaderActive          StyleColorID = 26
-	StyleColorSeparator             StyleColorID = 27
-	StyleColorSeparatorHovered      StyleColorID = 28
-	StyleColorSeparatorActive       StyleColorID = 29
-	StyleColorResizeGrip            StyleColorID = 30
-	StyleColorResizeGripHovered     StyleColorID = 31
-	StyleColorResizeGripActive      StyleColorID = 32
-	StyleColorTab                   StyleColorID = 33
-	StyleColorTabHovered            StyleColorID = 34
-	StyleColorTabActive             StyleColorID = 35
-	StyleColorTabUnfocused          StyleColorID = 36
-	StyleColorTabUnfocusedActive    StyleColorID = 37
-	StyleColorPlotLines             StyleColorID = 38
-	StyleColorPlotLinesHovered      StyleColorID = 39
-	StyleColorPlotHistogram         StyleColorID = 40
-	StyleColorPlotHistogramHovered  StyleColorID = 41
-	StyleColorTableHeaderBg         StyleColorID = 42 // Table header background
-	StyleColorTableBorderStrong     StyleColorID = 43 // Table outer and header borders (prefer using Alpha=1.0 here)
-	StyleColorTableBorderLight      StyleColorID = 44 // Table inner borders (prefer using Alpha=1.0 here)
-	StyleColorTableRowBg            StyleColorID = 45 // Table row background (even rows)
-	StyleColorTableRowBgAlt         StyleColorID = 46 // Table row background (odd rows)
-	StyleColorTextSelectedBg        StyleColorID = 47
-	StyleColorDragDropTarget        StyleColorID = 48
-	StyleColorNavHighlight          StyleColorID = 49 // Gamepad/keyboard: current highlighted item
-	StyleColorNavWindowingHighlight StyleColorID = 50 // Highlight window when using CTRL+TAB
-	StyleColorNavWindowingDarkening StyleColorID = 51 // Darken/colorize entire screen behind the CTRL+TAB window list, when active
-	StyleColorModalWindowDarkening  StyleColorID = 52 // Darken/colorize entire screen behind a modal window, when one is active
+	StyleColorText                  StyleColor = 0
+	StyleColorTextDisabled          StyleColor = 1
+	StyleColorWindowBg              StyleColor = 2
+	StyleColorChildBg               StyleColor = 3
+	StyleColorPopupBg               StyleColor = 4
+	StyleColorBorder                StyleColor = 5
+	StyleColorBorderShadow          StyleColor = 6
+	StyleColorFrameBg               StyleColor = 7
+	StyleColorFrameBgHovered        StyleColor = 8
+	StyleColorFrameBgActive         StyleColor = 9
+	StyleColorTitleBg               StyleColor = 10
+	StyleColorTitleBgActive         StyleColor = 11
+	StyleColorTitleBgCollapsed      StyleColor = 12
+	StyleColorMenuBarBg             StyleColor = 13
+	StyleColorScrollbarBg           StyleColor = 14
+	StyleColorScrollbarGrab         StyleColor = 15
+	StyleColorScrollbarGrabHovered  StyleColor = 16
+	StyleColorScrollbarGrabActive   StyleColor = 17
+	StyleColorCheckMark             StyleColor = 18
+	StyleColorSliderGrab            StyleColor = 19
+	StyleColorSliderGrabActive      StyleColor = 20
+	StyleColorButton                StyleColor = 21
+	StyleColorButtonHovered         StyleColor = 22
+	StyleColorButtonActive          StyleColor = 23
+	StyleColorHeader                StyleColor = 24
+	StyleColorHeaderHovered         StyleColor = 25
+	StyleColorHeaderActive          StyleColor = 26
+	StyleColorSeparator             StyleColor = 27
+	StyleColorSeparatorHovered      StyleColor = 28
+	StyleColorSeparatorActive       StyleColor = 29
+	StyleColorResizeGrip            StyleColor = 30
+	StyleColorResizeGripHovered     StyleColor = 31
+	StyleColorResizeGripActive      StyleColor = 32
+	StyleColorTab                   StyleColor = 33
+	StyleColorTabHovered            StyleColor = 34
+	StyleColorTabActive             StyleColor = 35
+	StyleColorTabUnfocused          StyleColor = 36
+	StyleColorTabUnfocusedActive    StyleColor = 37
+	StyleColorPlotLines             StyleColor = 38
+	StyleColorPlotLinesHovered      StyleColor = 39
+	StyleColorPlotHistogram         StyleColor = 40
+	StyleColorPlotHistogramHovered  StyleColor = 41
+	StyleColorTableHeaderBg         StyleColor = 42 // Table header background
+	StyleColorTableBorderStrong     StyleColor = 43 // Table outer and header borders (prefer using Alpha=1.0 here)
+	StyleColorTableBorderLight      StyleColor = 44 // Table inner borders (prefer using Alpha=1.0 here)
+	StyleColorTableRowBg            StyleColor = 45 // Table row background (even rows)
+	StyleColorTableRowBgAlt         StyleColor = 46 // Table row background (odd rows)
+	StyleColorTextSelectedBg        StyleColor = 47
+	StyleColorDragDropTarget        StyleColor = 48
+	StyleColorNavHighlight          StyleColor = 49 // Gamepad/keyboard: current highlighted item
+	StyleColorNavWindowingHighlight StyleColor = 50 // Highlight window when using CTRL+TAB
+	StyleColorNavWindowingDarkening StyleColor = 51 // Darken/colorize entire screen behind the CTRL+TAB window list, when active
+	StyleColorModalWindowDarkening  StyleColor = 52 // Darken/colorize entire screen behind a modal window, when one is active
 )
 
 // Style describes the overall graphical representation of the user interface.
@@ -142,7 +142,7 @@ func StyleColorsLight() {
 
 // PushStyleColor pushes the current style color for given ID on a stack and sets the given one.
 // To revert to the previous color, call PopStyleColor().
-func PushStyleColor(id StyleColorID, color Vec4) {
+func PushStyleColor(id StyleColor, color Vec4) {
 	colorArg, _ := color.wrapped()
 	C.iggPushStyleColor(C.int(id), colorArg)
 }
@@ -158,12 +158,12 @@ func PopStyleColor() {
 }
 
 // PushStyleVarFloat pushes a float value on the stack to temporarily modify a style variable.
-func PushStyleVarFloat(id StyleVarID, value float32) {
+func PushStyleVarFloat(id StyleVar, value float32) {
 	C.iggPushStyleVarFloat(C.int(id), C.float(value))
 }
 
 // PushStyleVarVec2 pushes a Vec2 value on the stack to temporarily modify a style variable.
-func PushStyleVarVec2(id StyleVarID, value Vec2) {
+func PushStyleVarVec2(id StyleVar, value Vec2) {
 	valueArg, _ := value.wrapped()
 	C.iggPushStyleVarVec2(C.int(id), valueArg)
 }
@@ -229,13 +229,13 @@ func (style Style) CellPadding() Vec2 {
 }
 
 // SetColor sets a color value of the UI style.
-func (style Style) SetColor(id StyleColorID, value Vec4) {
+func (style Style) SetColor(id StyleColor, value Vec4) {
 	valueArg, _ := value.wrapped()
 	C.iggStyleSetColor(style.handle(), C.int(id), valueArg)
 }
 
 // Color gets a color value from the UI style.
-func (style Style) Color(id StyleColorID) Vec4 {
+func (style Style) Color(id StyleColor) Vec4 {
 	var value Vec4
 	valueArg, valueFin := value.wrapped()
 	C.iggStyleGetColor(style.handle(), C.int(id), valueArg)

--- a/Tables.go
+++ b/Tables.go
@@ -56,13 +56,13 @@ type TableFlags int
 //      If you specify a value for 'inner_width' then effectively the scrolling space is known and Stretch or mixed Fixed/Stretch columns become meaningful again.
 // - Read on documentation at the top of imgui_tables.cpp for details.
 const (
-	// Features
+	// Features.
 
-	// TableFlagsNone default = 0
+	// TableFlagsNone default = 0.
 	TableFlagsNone TableFlags = 0
 	// TableFlagsResizable enables resizing columns.
 	TableFlagsResizable TableFlags = 1 << 0
-	// TableFlagsReorderable enables reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers)
+	// TableFlagsReorderable enables reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers).
 	TableFlagsReorderable TableFlags = 1 << 1
 	// TableFlagsHideable enables hiding/disabling columns in context menu.
 	TableFlagsHideable TableFlags = 1 << 2
@@ -73,9 +73,9 @@ const (
 	// TableFlagsContextMenuInBody right-click on columns body/contents will display table context menu. By default it is available in TableHeadersRow().
 	TableFlagsContextMenuInBody TableFlags = 1 << 5
 
-	// Decorations
+	// Decorations.
 
-	// TableFlagsRowBg Set each RowBg color with StyleColorTableRowBg or StyleColorTableRowBgAlt (equivalent to calling TableSetBgColor with TableBgFlagsRowBg0 on each row manually)
+	// TableFlagsRowBg Set each RowBg color with StyleColorTableRowBg or StyleColorTableRowBgAlt (equivalent to calling TableSetBgColor with TableBgFlagsRowBg0 on each row manually).
 	TableFlagsRowBg TableFlags = 1 << 6
 	// TableFlagsBordersInnerH draws horizontal borders between rows.
 	TableFlagsBordersInnerH TableFlags = 1 << 7
@@ -95,12 +95,12 @@ const (
 	TableFlagsBordersOuter = TableFlagsBordersOuterV | TableFlagsBordersOuterH
 	// TableFlagsBorders draws all borders.
 	TableFlagsBorders = TableFlagsBordersInner | TableFlagsBordersOuter
-	// TableFlagsNoBordersInBody [ALPHA] Disable vertical borders in columns Body (borders will always appears in Headers). -> May move to style
+	// TableFlagsNoBordersInBody [ALPHA] Disable vertical borders in columns Body (borders will always appears in Headers). -> May move to style.
 	TableFlagsNoBordersInBody TableFlags = 1 << 11
-	// TableFlagsNoBordersInBodyUntilResize [ALPHA] Disable vertical borders in columns Body until hovered for resize (borders will always appears in Headers). -> May move to style
+	// TableFlagsNoBordersInBodyUntilResize [ALPHA] Disable vertical borders in columns Body until hovered for resize (borders will always appears in Headers). -> May move to style.
 	TableFlagsNoBordersInBodyUntilResize TableFlags = 1 << 12
 
-	// Sizing Policy (read above for defaults)
+	// Sizing Policy (read above for defaults).
 
 	// TableFlagsSizingFixedFit columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching contents width.
 	TableFlagsSizingFixedFit TableFlags = 1 << 13
@@ -111,7 +111,7 @@ const (
 	// TableFlagsSizingStretchSame columns default to _WidthStretch with default weights all equal, unless overridden by TableSetupColumn().
 	TableFlagsSizingStretchSame TableFlags = 4 << 13
 
-	// Sizing Extra Options
+	// Sizing Extra Options.
 
 	// TableFlagsNoHostExtendX makes outer width auto-fit to columns, overriding outer_size.x value. Only available when ScrollX/ScrollY are disabled and Stretch columns are not used.
 	TableFlagsNoHostExtendX TableFlags = 1 << 16
@@ -122,12 +122,12 @@ const (
 	// TableFlagsPreciseWidths disables distributing remainder width to stretched columns (width allocation on a 100-wide table with 3 columns: Without this flag: 33,33,34. With this flag: 33,33,33). With larger number of columns, resizing will appear to be less smooth.
 	TableFlagsPreciseWidths TableFlags = 1 << 19
 
-	// Clipping
+	// Clipping.
 
 	// TableFlagsNoClip disables clipping rectangle for every individual columns (reduce draw command count, items will be able to overflow into other columns). Generally incompatible with TableSetupScrollFreeze().
 	TableFlagsNoClip TableFlags = 1 << 20
 
-	// Padding
+	// Padding.
 
 	// TableFlagsPadOuterX Default if BordersOuterV is on. Enable outer-most padding. Generally desirable if you have headers.
 	TableFlagsPadOuterX TableFlags = 1 << 21
@@ -136,14 +136,14 @@ const (
 	// TableFlagsNoPadInnerX disables inner padding between columns (double inner padding if BordersOuterV is on, single inner padding if BordersOuterV is off).
 	TableFlagsNoPadInnerX TableFlags = 1 << 23
 
-	// Scrolling
+	// Scrolling.
 
 	// TableFlagsScrollX enables horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Changes default sizing policy. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
 	TableFlagsScrollX TableFlags = 1 << 24
 	// TableFlagsScrollY enables vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
 	TableFlagsScrollY TableFlags = 1 << 25
 
-	// Sorting
+	// Sorting.
 
 	// TableFlagsSortMulti allows to hold shift when clicking headers to sort on multiple column. TableGetSortSpecs() may return specs where (SpecsCount > 1).
 	TableFlagsSortMulti TableFlags = 1 << 26
@@ -155,9 +155,9 @@ const (
 type TableColumnFlags int
 
 const (
-	// Input configuration flags
+	// Input configuration flags.
 
-	// TableColumnFlagsNone default = 0
+	// TableColumnFlagsNone default = 0.
 	TableColumnFlagsNone TableColumnFlags = 0
 	// TableColumnFlagsDefaultHide Default as a hidden/disabled column.
 	TableColumnFlagsDefaultHide TableColumnFlags = 1 << 0
@@ -192,15 +192,15 @@ const (
 	// TableColumnFlagsIndentDisable ignores current Indent value when entering cell (default for columns > 0). Indentation changes _within_ the cell will still be honored.
 	TableColumnFlagsIndentDisable TableColumnFlags = 1 << 15
 
-	// Output status flags, read-only via TableGetColumnFlags()
+	// Output status flags, read-only via TableGetColumnFlags().
 
 	// TableColumnFlagsIsEnabled Status: is enabled == not hidden by user/api (referred to as "Hide" in _DefaultHide and _NoHide) flags.
 	TableColumnFlagsIsEnabled TableColumnFlags = 1 << 20
 	// TableColumnFlagsIsVisible Status: is visible == is enabled AND not clipped by scrolling.
 	TableColumnFlagsIsVisible TableColumnFlags = 1 << 21
-	// TableColumnFlagsIsSorted Status: is currently part of the sort specs
+	// TableColumnFlagsIsSorted Status: is currently part of the sort specs.
 	TableColumnFlagsIsSorted TableColumnFlags = 1 << 22
-	// TableColumnFlagsIsHovered Status: is hovered by mouse
+	// TableColumnFlagsIsHovered Status: is hovered by mouse.
 	TableColumnFlagsIsHovered TableColumnFlags = 1 << 23
 )
 
@@ -208,9 +208,9 @@ const (
 type TableRowFlags int
 
 const (
-	// TableRowFlagsNone default = 0
+	// TableRowFlagsNone default = 0.
 	TableRowFlagsNone TableRowFlags = 0
-	// TableRowFlagsHeaders identify header row (set default background color + width of its contents accounted different for auto column width)
+	// TableRowFlagsHeaders identify header row (set default background color + width of its contents accounted different for auto column width).
 	TableRowFlagsHeaders TableRowFlags = 1 << 0
 )
 
@@ -228,13 +228,13 @@ const (
 type TableBgTarget int
 
 const (
-	// TableBgTargetNone default = 0
+	// TableBgTargetNone default = 0.
 	TableBgTargetNone TableBgTarget = 0
-	// TableBgTargetRowBg0 sets row background color 0 (generally used for background, automatically set when TableFlagsRowBg is used)
+	// TableBgTargetRowBg0 sets row background color 0 (generally used for background, automatically set when TableFlagsRowBg is used).
 	TableBgTargetRowBg0 TableBgTarget = 1
-	// TableBgTargetRowBg1 sets row background color 1 (generally used for selection marking)
+	// TableBgTargetRowBg1 sets row background color 1 (generally used for selection marking).
 	TableBgTargetRowBg1 TableBgTarget = 2
-	// TableBgTargetCellBg sets cell background color (top-most color)
+	// TableBgTargetCellBg sets cell background color (top-most color).
 	TableBgTargetCellBg TableBgTarget = 3
 )
 
@@ -242,7 +242,7 @@ const (
 type SortDirection int
 
 const (
-	// SortDirectionNone no sort
+	// SortDirectionNone no sort.
 	SortDirectionNone SortDirection = 0
 	// SortDirectionAscending sorts Ascending = 0->9, A->Z etc.
 	SortDirectionAscending SortDirection = 1

--- a/Tables.go
+++ b/Tables.go
@@ -3,6 +3,9 @@ package imgui
 // #include "wrapper/Tables.h"
 import "C"
 
+// TableFlags for BeginTableV().
+type TableFlags int
+
 // Tables
 // [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!
 // - Full-featured replacement for old Columns API.
@@ -56,32 +59,32 @@ const (
 	// Features
 
 	// TableFlagsNone default = 0
-	TableFlagsNone = 0
+	TableFlagsNone TableFlags = 0
 	// TableFlagsResizable enables resizing columns.
-	TableFlagsResizable = 1 << 0
+	TableFlagsResizable TableFlags = 1 << 0
 	// TableFlagsReorderable enables reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers)
-	TableFlagsReorderable = 1 << 1
+	TableFlagsReorderable TableFlags = 1 << 1
 	// TableFlagsHideable enables hiding/disabling columns in context menu.
-	TableFlagsHideable = 1 << 2
+	TableFlagsHideable TableFlags = 1 << 2
 	// TableFlagsSortable enables sorting. Call TableGetSortSpecs() to obtain sort specs. Also see TableFlagsSortMulti and TableFlagsSortTristate.
-	TableFlagsSortable = 1 << 3
+	TableFlagsSortable TableFlags = 1 << 3
 	// TableFlagsNoSavedSettings disables persisting columns order, width and sort settings in the .ini file.
-	TableFlagsNoSavedSettings = 1 << 4
+	TableFlagsNoSavedSettings TableFlags = 1 << 4
 	// TableFlagsContextMenuInBody right-click on columns body/contents will display table context menu. By default it is available in TableHeadersRow().
-	TableFlagsContextMenuInBody = 1 << 5
+	TableFlagsContextMenuInBody TableFlags = 1 << 5
 
 	// Decorations
 
 	// TableFlagsRowBg Set each RowBg color with StyleColorTableRowBg or StyleColorTableRowBgAlt (equivalent to calling TableSetBgColor with TableBgFlagsRowBg0 on each row manually)
-	TableFlagsRowBg = 1 << 6
+	TableFlagsRowBg TableFlags = 1 << 6
 	// TableFlagsBordersInnerH draws horizontal borders between rows.
-	TableFlagsBordersInnerH = 1 << 7
+	TableFlagsBordersInnerH TableFlags = 1 << 7
 	// TableFlagsBordersOuterH draws horizontal borders at the top and bottom.
-	TableFlagsBordersOuterH = 1 << 8
+	TableFlagsBordersOuterH TableFlags = 1 << 8
 	// TableFlagsBordersInnerV draws vertical borders between columns.
-	TableFlagsBordersInnerV = 1 << 9
+	TableFlagsBordersInnerV TableFlags = 1 << 9
 	// TableFlagsBordersOuterV draws vertical borders on the left and right sides.
-	TableFlagsBordersOuterV = 1 << 10
+	TableFlagsBordersOuterV TableFlags = 1 << 10
 	// TableFlagsBordersH draws horizontal borders.
 	TableFlagsBordersH = TableFlagsBordersInnerH | TableFlagsBordersOuterH
 	// TableFlagsBordersV draws vertical borders.
@@ -93,118 +96,122 @@ const (
 	// TableFlagsBorders draws all borders.
 	TableFlagsBorders = TableFlagsBordersInner | TableFlagsBordersOuter
 	// TableFlagsNoBordersInBody [ALPHA] Disable vertical borders in columns Body (borders will always appears in Headers). -> May move to style
-	TableFlagsNoBordersInBody = 1 << 11
+	TableFlagsNoBordersInBody TableFlags = 1 << 11
 	// TableFlagsNoBordersInBodyUntilResize [ALPHA] Disable vertical borders in columns Body until hovered for resize (borders will always appears in Headers). -> May move to style
-	TableFlagsNoBordersInBodyUntilResize = 1 << 12
+	TableFlagsNoBordersInBodyUntilResize TableFlags = 1 << 12
 
 	// Sizing Policy (read above for defaults)
 
 	// TableFlagsSizingFixedFit columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching contents width.
-	TableFlagsSizingFixedFit = 1 << 13
+	TableFlagsSizingFixedFit TableFlags = 1 << 13
 	// TableFlagsSizingFixedSame columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching the maximum contents width of all columns. Implicitly enable TableFlagsNoKeepColumnsVisible.
-	TableFlagsSizingFixedSame = 2 << 13
+	TableFlagsSizingFixedSame TableFlags = 2 << 13
 	// TableFlagsSizingStretchProp columns default to _WidthStretch with default weights proportional to each columns contents widths.
-	TableFlagsSizingStretchProp = 3 << 13
+	TableFlagsSizingStretchProp TableFlags = 3 << 13
 	// TableFlagsSizingStretchSame columns default to _WidthStretch with default weights all equal, unless overridden by TableSetupColumn().
-	TableFlagsSizingStretchSame = 4 << 13
+	TableFlagsSizingStretchSame TableFlags = 4 << 13
 
 	// Sizing Extra Options
 
 	// TableFlagsNoHostExtendX makes outer width auto-fit to columns, overriding outer_size.x value. Only available when ScrollX/ScrollY are disabled and Stretch columns are not used.
-	TableFlagsNoHostExtendX = 1 << 16
+	TableFlagsNoHostExtendX TableFlags = 1 << 16
 	// TableFlagsNoHostExtendY makes outer height stop exactly at outer_size.y (prevent auto-extending table past the limit). Only available when ScrollX/ScrollY are disabled. Data below the limit will be clipped and not visible.
-	TableFlagsNoHostExtendY = 1 << 17
+	TableFlagsNoHostExtendY TableFlags = 1 << 17
 	// TableFlagsNoKeepColumnsVisible disables keeping column always minimally visible when ScrollX is off and table gets too small. Not recommended if columns are resizable.
-	TableFlagsNoKeepColumnsVisible = 1 << 18
+	TableFlagsNoKeepColumnsVisible TableFlags = 1 << 18
 	// TableFlagsPreciseWidths disables distributing remainder width to stretched columns (width allocation on a 100-wide table with 3 columns: Without this flag: 33,33,34. With this flag: 33,33,33). With larger number of columns, resizing will appear to be less smooth.
-	TableFlagsPreciseWidths = 1 << 19
+	TableFlagsPreciseWidths TableFlags = 1 << 19
 
 	// Clipping
 
 	// TableFlagsNoClip disables clipping rectangle for every individual columns (reduce draw command count, items will be able to overflow into other columns). Generally incompatible with TableSetupScrollFreeze().
-	TableFlagsNoClip = 1 << 20
+	TableFlagsNoClip TableFlags = 1 << 20
 
 	// Padding
 
 	// TableFlagsPadOuterX Default if BordersOuterV is on. Enable outer-most padding. Generally desirable if you have headers.
-	TableFlagsPadOuterX = 1 << 21
+	TableFlagsPadOuterX TableFlags = 1 << 21
 	// TableFlagsNoPadOuterX Default if BordersOuterV is off. Disable outer-most padding.
-	TableFlagsNoPadOuterX = 1 << 22
+	TableFlagsNoPadOuterX TableFlags = 1 << 22
 	// TableFlagsNoPadInnerX disables inner padding between columns (double inner padding if BordersOuterV is on, single inner padding if BordersOuterV is off).
-	TableFlagsNoPadInnerX = 1 << 23
+	TableFlagsNoPadInnerX TableFlags = 1 << 23
 
 	// Scrolling
 
 	// TableFlagsScrollX enables horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Changes default sizing policy. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
-	TableFlagsScrollX = 1 << 24
+	TableFlagsScrollX TableFlags = 1 << 24
 	// TableFlagsScrollY enables vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
-	TableFlagsScrollY = 1 << 25
+	TableFlagsScrollY TableFlags = 1 << 25
 
 	// Sorting
 
 	// TableFlagsSortMulti allows to hold shift when clicking headers to sort on multiple column. TableGetSortSpecs() may return specs where (SpecsCount > 1).
-	TableFlagsSortMulti = 1 << 26
+	TableFlagsSortMulti TableFlags = 1 << 26
 	// TableFlagsSortTristate allows no sorting, disable default sorting. TableGetSortSpecs() may return specs where (SpecsCount == 0).
-	TableFlagsSortTristate = 1 << 27
+	TableFlagsSortTristate TableFlags = 1 << 27
 )
 
-// Flags for TableSetupColumn().
+// TableColumnFlags for TableSetupColumnV().
+type TableColumnFlags int
+
 const (
 	// Input configuration flags
 
 	// TableColumnFlagsNone default = 0
-	TableColumnFlagsNone = 0
+	TableColumnFlagsNone TableColumnFlags = 0
 	// TableColumnFlagsDefaultHide Default as a hidden/disabled column.
-	TableColumnFlagsDefaultHide = 1 << 0
+	TableColumnFlagsDefaultHide TableColumnFlags = 1 << 0
 	// TableColumnFlagsDefaultSort Default as a sorting column.
-	TableColumnFlagsDefaultSort = 1 << 1
+	TableColumnFlagsDefaultSort TableColumnFlags = 1 << 1
 	// TableColumnFlagsWidthStretch column will stretch. Preferable with horizontal scrolling disabled (default if table sizing policy is _SizingStretchSame or _SizingStretchProp).
-	TableColumnFlagsWidthStretch = 1 << 2
+	TableColumnFlagsWidthStretch TableColumnFlags = 1 << 2
 	// TableColumnFlagsWidthFixed column will not stretch. Preferable with horizontal scrolling enabled (default if table sizing policy is _SizingFixedFit and table is resizable).
-	TableColumnFlagsWidthFixed = 1 << 3
+	TableColumnFlagsWidthFixed TableColumnFlags = 1 << 3
 	// TableColumnFlagsNoResize disables manual resizing.
-	TableColumnFlagsNoResize = 1 << 4
+	TableColumnFlagsNoResize TableColumnFlags = 1 << 4
 	// TableColumnFlagsNoReorder disables manual reordering this column, this will also prevent other columns from crossing over this column.
-	TableColumnFlagsNoReorder = 1 << 5
+	TableColumnFlagsNoReorder TableColumnFlags = 1 << 5
 	// TableColumnFlagsNoHide disables ability to hide/disable this column.
-	TableColumnFlagsNoHide = 1 << 6
+	TableColumnFlagsNoHide TableColumnFlags = 1 << 6
 	// TableColumnFlagsNoClip disables clipping for this column (all NoClip columns will render in a same draw command).
-	TableColumnFlagsNoClip = 1 << 7
+	TableColumnFlagsNoClip TableColumnFlags = 1 << 7
 	// TableColumnFlagsNoSort disables ability to sort on this field (even if TableFlagsSortable is set on the table).
-	TableColumnFlagsNoSort = 1 << 8
+	TableColumnFlagsNoSort TableColumnFlags = 1 << 8
 	// TableColumnFlagsNoSortAscending disables ability to sort in the ascending direction.
-	TableColumnFlagsNoSortAscending = 1 << 9
+	TableColumnFlagsNoSortAscending TableColumnFlags = 1 << 9
 	// TableColumnFlagsNoSortDescending disables ability to sort in the descending direction.
-	TableColumnFlagsNoSortDescending = 1 << 10
+	TableColumnFlagsNoSortDescending TableColumnFlags = 1 << 10
 	// TableColumnFlagsNoHeaderWidth disables header text width contribution to automatic column width.
-	TableColumnFlagsNoHeaderWidth = 1 << 11
+	TableColumnFlagsNoHeaderWidth TableColumnFlags = 1 << 11
 	// TableColumnFlagsPreferSortAscending makes the initial sort direction Ascending when first sorting on this column (default).
-	TableColumnFlagsPreferSortAscending = 1 << 12
+	TableColumnFlagsPreferSortAscending TableColumnFlags = 1 << 12
 	// TableColumnFlagsPreferSortDescending makes the initial sort direction Descending when first sorting on this column.
-	TableColumnFlagsPreferSortDescending = 1 << 13
+	TableColumnFlagsPreferSortDescending TableColumnFlags = 1 << 13
 	// TableColumnFlagsIndentEnable uses current Indent value when entering cell (default for column 0).
-	TableColumnFlagsIndentEnable = 1 << 14
+	TableColumnFlagsIndentEnable TableColumnFlags = 1 << 14
 	// TableColumnFlagsIndentDisable ignores current Indent value when entering cell (default for columns > 0). Indentation changes _within_ the cell will still be honored.
-	TableColumnFlagsIndentDisable = 1 << 15
+	TableColumnFlagsIndentDisable TableColumnFlags = 1 << 15
 
 	// Output status flags, read-only via TableGetColumnFlags()
 
 	// TableColumnFlagsIsEnabled Status: is enabled == not hidden by user/api (referred to as "Hide" in _DefaultHide and _NoHide) flags.
-	TableColumnFlagsIsEnabled = 1 << 20
+	TableColumnFlagsIsEnabled TableColumnFlags = 1 << 20
 	// TableColumnFlagsIsVisible Status: is visible == is enabled AND not clipped by scrolling.
-	TableColumnFlagsIsVisible = 1 << 21
+	TableColumnFlagsIsVisible TableColumnFlags = 1 << 21
 	// TableColumnFlagsIsSorted Status: is currently part of the sort specs
-	TableColumnFlagsIsSorted = 1 << 22
+	TableColumnFlagsIsSorted TableColumnFlags = 1 << 22
 	// TableColumnFlagsIsHovered Status: is hovered by mouse
-	TableColumnFlagsIsHovered = 1 << 23
+	TableColumnFlagsIsHovered TableColumnFlags = 1 << 23
 )
 
-// Flags for TableNextRow().
+// TableRowFlags for TableNextRowV().
+type TableRowFlags int
+
 const (
 	// TableRowFlagsNone default = 0
-	TableRowFlagsNone = 0
+	TableRowFlagsNone TableRowFlags = 0
 	// TableRowFlagsHeaders identify header row (set default background color + width of its contents accounted different for auto column width)
-	TableRowFlagsHeaders = 1 << 0
+	TableRowFlagsHeaders TableRowFlags = 1 << 0
 )
 
 // Enum for TableSetBgColor()
@@ -264,7 +271,7 @@ const (
 //   of "available space" doesn't make sense.
 // - Even if not really useful, we allow 'innerWidth < outerSize.x' for consistency and to facilitate understanding
 //   of what the value does.
-func BeginTableV(id string, columnsCount int, flags int, outerSize Vec2, innerWidth float32) bool {
+func BeginTableV(id string, columnsCount int, flags TableFlags, outerSize Vec2, innerWidth float32) bool {
 	idArg, idFin := wrapString(id)
 	defer idFin()
 	outerSizeArg, _ := outerSize.wrapped()
@@ -283,7 +290,7 @@ func EndTable() {
 }
 
 // TableNextRowV appends into the first cell of a new row.
-func TableNextRowV(flags int, minRowHeight float32) {
+func TableNextRowV(flags TableRowFlags, minRowHeight float32) {
 	C.iggTableNextRow(C.int(flags), C.float(minRowHeight))
 }
 
@@ -311,7 +318,7 @@ func TableSetColumnIndex(columnN int) bool {
 // - You may manually submit headers using TableNextRow() + TableHeader() calls, but this is only useful in
 //   some advanced use cases (e.g. adding custom widgets in header row).
 // - Use TableSetupScrollFreeze() to lock columns/rows so they stay visible when scrolled.
-func TableSetupColumnV(label string, flags int, initWidthOrHeight float32, userID uint) {
+func TableSetupColumnV(label string, flags TableColumnFlags, initWidthOrHeight float32, userID uint) {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	C.iggTableSetupColumn(labelArg, C.int(flags), C.float(initWidthOrHeight), C.uint(userID))

--- a/Tables.go
+++ b/Tables.go
@@ -214,34 +214,40 @@ const (
 	TableRowFlagsHeaders TableRowFlags = 1 << 0
 )
 
-// Enum for TableSetBgColor()
+// TableBgTarget for TableSetBgColor
+//
 // Background colors are rendering in 3 layers:
 //  - Layer 0: draw with RowBg0 color if set, otherwise draw with ColumnBg0 if set.
 //  - Layer 1: draw with RowBg1 color if set, otherwise draw with ColumnBg1 if set.
 //  - Layer 2: draw with CellBg color if set.
-// The purpose of the two row/columns layers is to let you decide if a background color changes should override or blend with the existing color.
+// The purpose of the two row/columns layers is to let you decide if a
+// background color changes should override or blend with the existing color.
 // When using TableFlagsRowBg on the table, each row has the RowBg0 color automatically set for odd/even rows.
 // If you set the color of RowBg0 target, your color will override the existing RowBg0 color.
 // If you set the color of RowBg1 or ColumnBg1 target, your color will blend over the RowBg0 color.
+type TableBgTarget int
+
 const (
 	// TableBgTargetNone default = 0
-	TableBgTargetNone = 0
+	TableBgTargetNone TableBgTarget = 0
 	// TableBgTargetRowBg0 sets row background color 0 (generally used for background, automatically set when TableFlagsRowBg is used)
-	TableBgTargetRowBg0 = 1
+	TableBgTargetRowBg0 TableBgTarget = 1
 	// TableBgTargetRowBg1 sets row background color 1 (generally used for selection marking)
-	TableBgTargetRowBg1 = 2
+	TableBgTargetRowBg1 TableBgTarget = 2
 	// TableBgTargetCellBg sets cell background color (top-most color)
-	TableBgTargetCellBg = 3
+	TableBgTargetCellBg TableBgTarget = 3
 )
 
-// A sorting direction.
+// SortDirection used in TableColumnSortSpecs, etc.
+type SortDirection int
+
 const (
 	// SortDirectionNone no sort
-	SortDirectionNone = 0
+	SortDirectionNone SortDirection = 0
 	// SortDirectionAscending sorts Ascending = 0->9, A->Z etc.
-	SortDirectionAscending = 1
+	SortDirectionAscending SortDirection = 1
 	// SortDirectionDescending sorts Descending = 9->0, Z->A etc.
-	SortDirectionDescending = 2
+	SortDirectionDescending SortDirection = 2
 )
 
 // BeginTableV creates a table
@@ -382,13 +388,13 @@ func TableGetColumnFlags() int {
 }
 
 // TableSetBgColorV changes the color of a cell, row, or column. See TableBgTarget flags for details.
-func TableSetBgColorV(target int, color Vec4, columnN int) {
+func TableSetBgColorV(target TableBgTarget, color Vec4, columnN int) {
 	colorArg, _ := color.wrapped()
 	C.iggTableSetBgColor(C.int(target), colorArg, C.int(columnN))
 }
 
 // TableSetBgColor calls TableSetBgColorV(target, color, -1).
-func TableSetBgColor(target int, color Vec4) {
+func TableSetBgColor(target TableBgTarget, color Vec4) {
 	TableSetBgColorV(target, color, -1)
 }
 
@@ -415,10 +421,10 @@ func (specs TableSortSpecs) handle() C.IggTableSortSpecs {
 
 // TableColumnSortSpecs is a sorting specification for one column of a table (sizeof == 12 bytes).
 type TableColumnSortSpecs struct {
-	ColumnUserID  uint  // User id of the column (if specified by a TableSetupColumn() call)
-	ColumnIndex   int16 // Index of the column
-	SortOrder     int16 // Index within parent TableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
-	SortDirection int   // SortDirectionAscending or SortDirectionDescending (you can use this or SortSign, whichever is more convenient for your sort function)
+	ColumnUserID  uint          // User id of the column (if specified by a TableSetupColumn() call)
+	ColumnIndex   int16         // Index of the column
+	SortOrder     int16         // Index within parent TableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
+	SortDirection SortDirection // SortDirectionAscending or SortDirectionDescending (you can use this or SortSign, whichever is more convenient for your sort function)
 }
 
 // Specs returns columns sort spec array.
@@ -433,7 +439,7 @@ func (specs TableSortSpecs) Specs() []TableColumnSortSpecs {
 			ColumnUserID:  uint(out.ColumnUserID),
 			ColumnIndex:   int16(out.ColumnIndex),
 			SortOrder:     int16(out.SortOrder),
-			SortDirection: int(out.SortDirection),
+			SortDirection: SortDirection(out.SortDirection),
 		}
 	}
 	return columnSpecs

--- a/Widgets.go
+++ b/Widgets.go
@@ -1200,28 +1200,31 @@ func ColumnsCount() int {
 	return int(C.iggGetColumnsCount())
 }
 
+// TabBarFlags for BeginTabBarV().
+type TabBarFlags int
+
 const (
 	// TabBarFlagsNone default = 0.
-	TabBarFlagsNone = 0
+	TabBarFlagsNone TabBarFlags = 0
 	// TabBarFlagsReorderable Allow manually dragging tabs to re-order them + New tabs are appended at the end of list
-	TabBarFlagsReorderable = 1 << 0
+	TabBarFlagsReorderable TabBarFlags = 1 << 0
 	// TabBarFlagsAutoSelectNewTabs Automatically select new tabs when they appear
-	TabBarFlagsAutoSelectNewTabs = 1 << 1
+	TabBarFlagsAutoSelectNewTabs TabBarFlags = 1 << 1
 	// TabBarFlagsTabListPopupButton Disable buttons to open the tab list popup
-	TabBarFlagsTabListPopupButton = 1 << 2
+	TabBarFlagsTabListPopupButton TabBarFlags = 1 << 2
 	// TabBarFlagsNoCloseWithMiddleMouseButton Disable behavior of closing tabs (that are submitted with p_open != NULL)
 	// with middle mouse button. You can still repro this behavior on user's side with if
 	// (IsItemHovered() && IsMouseClicked(2)) *p_open = false.
-	TabBarFlagsNoCloseWithMiddleMouseButton = 1 << 3
+	TabBarFlagsNoCloseWithMiddleMouseButton TabBarFlags = 1 << 3
 	// TabBarFlagsNoTabListScrollingButtons Disable scrolling buttons (apply when fitting policy is
 	// TabBarFlagsFittingPolicyScroll)
-	TabBarFlagsNoTabListScrollingButtons = 1 << 4
+	TabBarFlagsNoTabListScrollingButtons TabBarFlags = 1 << 4
 	// TabBarFlagsNoTooltip Disable tooltips when hovering a tab
-	TabBarFlagsNoTooltip = 1 << 5
+	TabBarFlagsNoTooltip TabBarFlags = 1 << 5
 	// TabBarFlagsFittingPolicyResizeDown Resize tabs when they don't fit
-	TabBarFlagsFittingPolicyResizeDown = 1 << 6
+	TabBarFlagsFittingPolicyResizeDown TabBarFlags = 1 << 6
 	// TabBarFlagsFittingPolicyScroll Add scroll buttons when tabs don't fit
-	TabBarFlagsFittingPolicyScroll = 1 << 7
+	TabBarFlagsFittingPolicyScroll TabBarFlags = 1 << 7
 	// TabBarFlagsFittingPolicyMask combines
 	// TabBarFlagsFittingPolicyResizeDown and TabBarFlagsFittingPolicyScroll
 	TabBarFlagsFittingPolicyMask = TabBarFlagsFittingPolicyResizeDown | TabBarFlagsFittingPolicyScroll
@@ -1230,7 +1233,7 @@ const (
 )
 
 // BeginTabBarV create and append into a TabBar.
-func BeginTabBarV(strID string, flags int) bool {
+func BeginTabBarV(strID string, flags TabBarFlags) bool {
 	idArg, idFin := wrapString(strID)
 	defer idFin()
 
@@ -1247,33 +1250,36 @@ func EndTabBar() {
 	C.iggEndTabBar()
 }
 
+// TabItemFlags for BeginTabItemV(), BeginTabButtonV().
+type TabItemFlags int
+
 const (
 	// TabItemFlagsNone default = 0
-	TabItemFlagsNone = 0
+	TabItemFlagsNone TabItemFlags = 0
 	// TabItemFlagsUnsavedDocument Append '*' to title without affecting the ID, as a convenience to avoid using the
 	// ### operator. Also: tab is selected on closure and closure is deferred by one frame to allow code to undo it
 	// without flicker.
-	TabItemFlagsUnsavedDocument = 1 << 0
+	TabItemFlagsUnsavedDocument TabItemFlags = 1 << 0
 	// TabItemFlagsSetSelected Trigger flag to programmatically make the tab selected when calling BeginTabItem()
-	TabItemFlagsSetSelected = 1 << 1
+	TabItemFlagsSetSelected TabItemFlags = 1 << 1
 	// TabItemFlagsNoCloseWithMiddleMouseButton  Disable behavior of closing tabs (that are submitted with
 	// p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if
 	// (IsItemHovered() && IsMouseClicked(2)) *p_open = false.
-	TabItemFlagsNoCloseWithMiddleMouseButton = 1 << 2
+	TabItemFlagsNoCloseWithMiddleMouseButton TabItemFlags = 1 << 2
 	// TabItemFlagsNoPushID Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem()
-	TabItemFlagsNoPushID = 1 << 3
+	TabItemFlagsNoPushID TabItemFlags = 1 << 3
 	// TabItemFlagsNoTooltip Disable tooltip for the given tab
-	TabItemFlagsNoTooltip = 1 << 4
+	TabItemFlagsNoTooltip TabItemFlags = 1 << 4
 	// TabItemFlagsNoReorder Disable reordering this tab or having another tab cross over this tab
-	TabItemFlagsNoReorder = 1 << 5
+	TabItemFlagsNoReorder TabItemFlags = 1 << 5
 	// TabItemFlagsLeading Enforce the tab position to the left of the tab bar (after the tab list popup button)
-	TabItemFlagsLeading = 1 << 6
+	TabItemFlagsLeading TabItemFlags = 1 << 6
 	// TabItemFlagsTrailing Enforce the tab position to the right of the tab bar (before the scrolling buttons)
-	TabItemFlagsTrailing = 1 << 7
+	TabItemFlagsTrailing TabItemFlags = 1 << 7
 )
 
 // BeginTabItemV create a Tab. Returns true if the Tab is selected.
-func BeginTabItemV(label string, open *bool, flags int) bool {
+func BeginTabItemV(label string, open *bool, flags TabItemFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 
@@ -1295,7 +1301,7 @@ func EndTabItem() {
 }
 
 // TabItemButtonV create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
-func TabItemButtonV(label string, flags int) bool {
+func TabItemButtonV(label string, flags TabItemFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	return C.iggTabItemButton(labelArg, C.int(flags)) != 0

--- a/Widgets.go
+++ b/Widgets.go
@@ -43,11 +43,11 @@ const (
 	// ButtonFlagsNone is no flag applied.
 	ButtonFlagsNone ButtonFlags = 0
 	// ButtonFlagsMouseButtonLeft reacts on left mouse button (default).
-	ButtonFlagsMouseButtonLeft ButtonFlags = 1 << iota
+	ButtonFlagsMouseButtonLeft ButtonFlags = 1 << 0
 	// ButtonFlagsMouseButtonRight reacts on right mouse button.
-	ButtonFlagsMouseButtonRight
+	ButtonFlagsMouseButtonRight ButtonFlags = 1 << 1
 	// ButtonFlagsMouseButtonMiddle reacts on center mouse button.
-	ButtonFlagsMouseButtonMiddle
+	ButtonFlagsMouseButtonMiddle ButtonFlags = 1 << 2
 )
 
 // InvisibleButtonV returns true if it is clicked.
@@ -182,13 +182,13 @@ const (
 	// SliderFlagsNone is no flag applied.
 	SliderFlagsNone SliderFlags = 0
 	// SliderFlagsAlwaysClamp clamps value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds.
-	SliderFlagsAlwaysClamp SliderFlags = 1 << (iota + 4)
+	SliderFlagsAlwaysClamp SliderFlags = 1 << 0
 	// SliderFlagsLogarithmic makes the widget logarithmic (linear otherwise). Consider using SliderFlagNoRoundToFormat with this if using a format-string with small amount of digits.
-	SliderFlagsLogarithmic
+	SliderFlagsLogarithmic SliderFlags = 1 << 1
 	// SliderFlagsNoRoundToFormat disables rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits)
-	SliderFlagsNoRoundToFormat
+	SliderFlagsNoRoundToFormat SliderFlags = 1 << 2
 	// SliderFlagsNoInput disables CTRL+Click or Enter key allowing to input text directly into the widget
-	SliderFlagsNoInput
+	SliderFlagsNoInput SliderFlags = 1 << 3
 )
 
 // DragFloatV creates a draggable slider for floats.

--- a/Widgets.go
+++ b/Widgets.go
@@ -512,52 +512,55 @@ func VSliderInt(label string, size Vec2, value *int32, min, max int32) bool {
 	return VSliderIntV(label, size, value, min, max, "%d", SliderFlagsNone)
 }
 
+// InputTextFlags for InputTextV(), etc.
+type InputTextFlags int
+
 const (
 	// InputTextFlagsNone sets everything default.
-	InputTextFlagsNone = 0
+	InputTextFlagsNone InputTextFlags = 0
 	// InputTextFlagsCharsDecimal allows 0123456789.+-
-	InputTextFlagsCharsDecimal = 1 << 0
+	InputTextFlagsCharsDecimal InputTextFlags = 1 << 0
 	// InputTextFlagsCharsHexadecimal allow 0123456789ABCDEFabcdef
-	InputTextFlagsCharsHexadecimal = 1 << 1
+	InputTextFlagsCharsHexadecimal InputTextFlags = 1 << 1
 	// InputTextFlagsCharsUppercase turns a..z into A..Z.
-	InputTextFlagsCharsUppercase = 1 << 2
+	InputTextFlagsCharsUppercase InputTextFlags = 1 << 2
 	// InputTextFlagsCharsNoBlank filters out spaces, tabs.
-	InputTextFlagsCharsNoBlank = 1 << 3
+	InputTextFlagsCharsNoBlank InputTextFlags = 1 << 3
 	// InputTextFlagsAutoSelectAll selects entire text when first taking mouse focus.
-	InputTextFlagsAutoSelectAll = 1 << 4
+	InputTextFlagsAutoSelectAll InputTextFlags = 1 << 4
 	// InputTextFlagsEnterReturnsTrue returns 'true' when Enter is pressed (as opposed to when the value was modified).
-	InputTextFlagsEnterReturnsTrue = 1 << 5
+	InputTextFlagsEnterReturnsTrue InputTextFlags = 1 << 5
 	// InputTextFlagsCallbackCompletion for callback on pressing TAB (for completion handling).
-	InputTextFlagsCallbackCompletion = 1 << 6
+	InputTextFlagsCallbackCompletion InputTextFlags = 1 << 6
 	// InputTextFlagsCallbackHistory for callback on pressing Up/Down arrows (for history handling).
-	InputTextFlagsCallbackHistory = 1 << 7
+	InputTextFlagsCallbackHistory InputTextFlags = 1 << 7
 	// InputTextFlagsCallbackAlways for callback on each iteration. User code may query cursor position, modify text buffer.
-	InputTextFlagsCallbackAlways = 1 << 8
+	InputTextFlagsCallbackAlways InputTextFlags = 1 << 8
 	// InputTextFlagsCallbackCharFilter for callback on character inputs to replace or discard them.
 	// Modify 'EventChar' to replace or discard, or return 1 in callback to discard.
-	InputTextFlagsCallbackCharFilter = 1 << 9
+	InputTextFlagsCallbackCharFilter InputTextFlags = 1 << 9
 	// InputTextFlagsAllowTabInput when pressing TAB to input a '\t' character into the text field.
-	InputTextFlagsAllowTabInput = 1 << 10
+	InputTextFlagsAllowTabInput InputTextFlags = 1 << 10
 	// InputTextFlagsCtrlEnterForNewLine in multi-line mode, unfocus with Enter, add new line with Ctrl+Enter
 	// (default is opposite: unfocus with Ctrl+Enter, add line with Enter).
-	InputTextFlagsCtrlEnterForNewLine = 1 << 11
+	InputTextFlagsCtrlEnterForNewLine InputTextFlags = 1 << 11
 	// InputTextFlagsNoHorizontalScroll disables following the cursor horizontally.
-	InputTextFlagsNoHorizontalScroll = 1 << 12
+	InputTextFlagsNoHorizontalScroll InputTextFlags = 1 << 12
 	// InputTextFlagsAlwaysInsertMode sets insert mode.
-	InputTextFlagsAlwaysInsertMode = 1 << 13
+	InputTextFlagsAlwaysInsertMode InputTextFlags = 1 << 13
 	// InputTextFlagsReadOnly sets read-only mode.
-	InputTextFlagsReadOnly = 1 << 14
+	InputTextFlagsReadOnly InputTextFlags = 1 << 14
 	// InputTextFlagsPassword sets password mode, display all characters as '*'.
-	InputTextFlagsPassword = 1 << 15
+	InputTextFlagsPassword InputTextFlags = 1 << 15
 	// InputTextFlagsNoUndoRedo disables undo/redo. Note that input text owns the text data while active,
 	// if you want to provide your own undo/redo stack you need e.g. to call ClearActiveID().
-	InputTextFlagsNoUndoRedo = 1 << 16
+	InputTextFlagsNoUndoRedo InputTextFlags = 1 << 16
 	// InputTextFlagsCharsScientific allows 0123456789.+-*/eE (Scientific notation input).
-	InputTextFlagsCharsScientific = 1 << 17
+	InputTextFlagsCharsScientific InputTextFlags = 1 << 17
 	// inputTextFlagsCallbackResize for callback on buffer capacity change requests.
-	inputTextFlagsCallbackResize = 1 << 18
+	inputTextFlagsCallbackResize InputTextFlags = 1 << 18
 	// ImGuiInputTextFlagsCallbackEdit for callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)
-	ImGuiInputTextFlagsCallbackEdit = 1 << 19
+	ImGuiInputTextFlagsCallbackEdit InputTextFlags = 1 << 19
 )
 
 // InputTextV creates a text field for dynamic text input.
@@ -568,7 +571,7 @@ const (
 // The provided callback is called for any of the requested InputTextFlagsCallback* flags.
 //
 // To implement a character limit, provide a callback that drops input characters when the requested length has been reached.
-func InputTextV(label string, text *string, flags int, cb InputTextCallback) bool {
+func InputTextV(label string, text *string, flags InputTextFlags, cb InputTextCallback) bool {
 	return inputTextSingleline(label, nil, text, flags, cb)
 }
 
@@ -585,7 +588,7 @@ func InputText(label string, text *string) bool {
 // The provided callback is called for any of the requested InputTextFlagsCallback* flags.
 //
 // To implement a character limit, provide a callback that drops input characters when the requested length has been reached.
-func InputTextWithHintV(label string, hint string, text *string, flags int, cb InputTextCallback) bool {
+func InputTextWithHintV(label string, hint string, text *string, flags InputTextFlags, cb InputTextCallback) bool {
 	return inputTextSingleline(label, &hint, text, flags, cb)
 }
 
@@ -594,7 +597,7 @@ func InputTextWithHint(label string, hint string, text *string) bool {
 	return InputTextWithHintV(label, hint, text, 0, nil)
 }
 
-func inputTextSingleline(label string, hint *string, text *string, flags int, cb InputTextCallback) bool {
+func inputTextSingleline(label string, hint *string, text *string, flags InputTextFlags, cb InputTextCallback) bool {
 	if text == nil {
 		panic("text can't be nil")
 	}
@@ -624,7 +627,7 @@ func inputTextSingleline(label string, hint *string, text *string, flags int, cb
 // The provided callback is called for any of the requested InputTextFlagsCallback* flags.
 //
 // To implement a character limit, provide a callback that drops input characters when the requested length has been reached.
-func InputTextMultilineV(label string, text *string, size Vec2, flags int, cb InputTextCallback) bool {
+func InputTextMultilineV(label string, text *string, size Vec2, flags InputTextFlags, cb InputTextCallback) bool {
 	if text == nil {
 		panic("text can't be nil")
 	}
@@ -647,7 +650,7 @@ func InputTextMultiline(label string, text *string) bool {
 }
 
 // InputIntV creates a input field for integer type.
-func InputIntV(label string, value *int32, step int, stepFast int, flags int) bool {
+func InputIntV(label string, value *int32, step int, stepFast int, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	valueArg, valueFin := wrapInt32(value)

--- a/Widgets.go
+++ b/Widgets.go
@@ -133,30 +133,33 @@ func ProgressBar(fraction float32) {
 	ProgressBarV(fraction, Vec2{X: -math.SmallestNonzeroFloat32, Y: 0}, "")
 }
 
+// ComboFlags for BeginComboV()
+type ComboFlags int
+
 const (
-	// ComboFlagNone default = 0
-	ComboFlagNone = 0
-	// ComboFlagPopupAlignLeft aligns the popup toward the left by default.
-	ComboFlagPopupAlignLeft = 1 << 0
-	// ComboFlagHeightSmall has max ~4 items visible.
+	// ComboFlagsNone default = 0
+	ComboFlagsNone ComboFlags = 0
+	// ComboFlagsPopupAlignLeft aligns the popup toward the left by default.
+	ComboFlagsPopupAlignLeft ComboFlags = 1 << 0
+	// ComboFlagsHeightSmall has max ~4 items visible.
 	// Tip: If you want your combo popup to be a specific size you can use SetNextWindowSizeConstraints() prior to calling BeginCombo().
-	ComboFlagHeightSmall = 1 << 1
-	// ComboFlagHeightRegular has max ~8 items visible (default).
-	ComboFlagHeightRegular = 1 << 2
-	// ComboFlagHeightLarge has max ~20 items visible.
-	ComboFlagHeightLarge = 1 << 3
-	// ComboFlagHeightLargest has as many fitting items as possible.
-	ComboFlagHeightLargest = 1 << 4
-	// ComboFlagNoArrowButton displays on the preview box without the square arrow button.
-	ComboFlagNoArrowButton = 1 << 5
-	// ComboFlagNoPreview displays only a square arrow button.
-	ComboFlagNoPreview = 1 << 6
+	ComboFlagsHeightSmall ComboFlags = 1 << 1
+	// ComboFlagsHeightRegular has max ~8 items visible (default).
+	ComboFlagsHeightRegular ComboFlags = 1 << 2
+	// ComboFlagsHeightLarge has max ~20 items visible.
+	ComboFlagsHeightLarge ComboFlags = 1 << 3
+	// ComboFlagsHeightLargest has as many fitting items as possible.
+	ComboFlagsHeightLargest ComboFlags = 1 << 4
+	// ComboFlagsNoArrowButton displays on the preview box without the square arrow button.
+	ComboFlagsNoArrowButton ComboFlags = 1 << 5
+	// ComboFlagsNoPreview displays only a square arrow button.
+	ComboFlagsNoPreview ComboFlags = 1 << 6
 )
 
 // BeginComboV creates a combo box with complete control over the content to the user.
 // Call EndCombo() if this function returns true.
 // flags are the ComboFlags to apply.
-func BeginComboV(label, previewValue string, flags int) bool {
+func BeginComboV(label, previewValue string, flags ComboFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	previewValueArg, previewValueFin := wrapString(previewValue)

--- a/Widgets.go
+++ b/Widgets.go
@@ -180,15 +180,15 @@ type SliderFlags int
 
 const (
 	// SliderFlagsNone is no flag applied.
-	SliderFlagsNone = 0
+	SliderFlagsNone SliderFlags = 0
 	// SliderFlagsAlwaysClamp clamps value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds.
-	SliderFlagsAlwaysClamp = 1 << 4
+	SliderFlagsAlwaysClamp SliderFlags = 1 << (iota + 4)
 	// SliderFlagsLogarithmic makes the widget logarithmic (linear otherwise). Consider using SliderFlagNoRoundToFormat with this if using a format-string with small amount of digits.
-	SliderFlagsLogarithmic = 1 << 5
+	SliderFlagsLogarithmic
 	// SliderFlagsNoRoundToFormat disables rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits)
-	SliderFlagsNoRoundToFormat = 1 << 6
+	SliderFlagsNoRoundToFormat
 	// SliderFlagsNoInput disables CTRL+Click or Enter key allowing to input text directly into the widget
-	SliderFlagsNoInput = 1 << 7
+	SliderFlagsNoInput
 )
 
 // DragFloatV creates a draggable slider for floats.

--- a/Widgets.go
+++ b/Widgets.go
@@ -664,62 +664,65 @@ func InputInt(label string, value *int32) bool {
 	return InputIntV(label, value, 1, 100, 0)
 }
 
+// ColorEditFlags for ColorEdit3V(), etc.
+type ColorEditFlags int
+
 const (
 	// ColorEditFlagsNone default = 0
-	ColorEditFlagsNone = 0
+	ColorEditFlagsNone ColorEditFlags = 0
 	// ColorEditFlagsNoAlpha ignores Alpha component (read 3 components from the input pointer).
-	ColorEditFlagsNoAlpha = 1 << 1
+	ColorEditFlagsNoAlpha ColorEditFlags = 1 << 1
 	// ColorEditFlagsNoPicker disables picker when clicking on colored square.
-	ColorEditFlagsNoPicker = 1 << 2
+	ColorEditFlagsNoPicker ColorEditFlags = 1 << 2
 	// ColorEditFlagsNoOptions disables toggling options menu when right-clicking on inputs/small preview.
-	ColorEditFlagsNoOptions = 1 << 3
+	ColorEditFlagsNoOptions ColorEditFlags = 1 << 3
 	// ColorEditFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs)
-	ColorEditFlagsNoSmallPreview = 1 << 4
+	ColorEditFlagsNoSmallPreview ColorEditFlags = 1 << 4
 	// ColorEditFlagsNoInputs disables inputs sliders/text widgets (e.g. to show only the small preview colored square).
-	ColorEditFlagsNoInputs = 1 << 5
+	ColorEditFlagsNoInputs ColorEditFlags = 1 << 5
 	// ColorEditFlagsNoTooltip disables tooltip when hovering the preview.
-	ColorEditFlagsNoTooltip = 1 << 6
+	ColorEditFlagsNoTooltip ColorEditFlags = 1 << 6
 	// ColorEditFlagsNoLabel disables display of inline text label (the label is still forwarded to the tooltip and picker).
-	ColorEditFlagsNoLabel = 1 << 7
+	ColorEditFlagsNoLabel ColorEditFlags = 1 << 7
 	// ColorEditFlagsNoSidePreview disables bigger color preview on right side of the picker, use small colored square preview instead.
-	ColorEditFlagsNoSidePreview = 1 << 8
+	ColorEditFlagsNoSidePreview ColorEditFlags = 1 << 8
 	// ColorEditFlagsNoDragDrop disables drag and drop target. ColorButton: disable drag and drop source.
-	ColorEditFlagsNoDragDrop = 1 << 9
+	ColorEditFlagsNoDragDrop ColorEditFlags = 1 << 9
 	// ColorEditFlagsNoBorder disables border (which is enforced by default)
-	ColorEditFlagsNoBorder = 1 << 10
+	ColorEditFlagsNoBorder ColorEditFlags = 1 << 10
 
 	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions().
 	// The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call
 	// SetColorEditOptions() during startup.
 
 	// ColorEditFlagsAlphaBar shows vertical alpha bar/gradient in picker.
-	ColorEditFlagsAlphaBar = 1 << 16
+	ColorEditFlagsAlphaBar ColorEditFlags = 1 << 16
 	// ColorEditFlagsAlphaPreview displays preview as a transparent color over a checkerboard, instead of opaque.
-	ColorEditFlagsAlphaPreview = 1 << 17
+	ColorEditFlagsAlphaPreview ColorEditFlags = 1 << 17
 	// ColorEditFlagsAlphaPreviewHalf displays half opaque / half checkerboard, instead of opaque.
-	ColorEditFlagsAlphaPreviewHalf = 1 << 18
+	ColorEditFlagsAlphaPreviewHalf ColorEditFlags = 1 << 18
 	// ColorEditFlagsHDR = (WIP) surrently only disable 0.0f..1.0f limits in RGBA edition.
 	// Note: you probably want to use ImGuiColorEditFlags_Float flag as well.
-	ColorEditFlagsHDR = 1 << 19
+	ColorEditFlagsHDR ColorEditFlags = 1 << 19
 	// ColorEditFlagsRGB sets the format as RGB
-	ColorEditFlagsRGB = 1 << 20
+	ColorEditFlagsRGB ColorEditFlags = 1 << 20
 	// ColorEditFlagsHSV sets the format as HSV
-	ColorEditFlagsHSV = 1 << 21
+	ColorEditFlagsHSV ColorEditFlags = 1 << 21
 	// ColorEditFlagsHEX sets the format as HEX
-	ColorEditFlagsHEX = 1 << 22
+	ColorEditFlagsHEX ColorEditFlags = 1 << 22
 	// ColorEditFlagsUint8 _display_ values formatted as 0..255.
-	ColorEditFlagsUint8 = 1 << 23
+	ColorEditFlagsUint8 ColorEditFlags = 1 << 23
 	// ColorEditFlagsFloat _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.
-	ColorEditFlagsFloat = 1 << 24
+	ColorEditFlagsFloat ColorEditFlags = 1 << 24
 
 	// ColorEditFlagsPickerHueBar shows bar for Hue, rectangle for Sat/Value.
-	ColorEditFlagsPickerHueBar = 1 << 25
+	ColorEditFlagsPickerHueBar ColorEditFlags = 1 << 25
 	// ColorEditFlagsPickerHueWheel shows wheel for Hue, triangle for Sat/Value.
-	ColorEditFlagsPickerHueWheel = 1 << 26
+	ColorEditFlagsPickerHueWheel ColorEditFlags = 1 << 26
 	// ColorEditFlagsInputRGB enables input and output data in RGB format.
-	ColorEditFlagsInputRGB = 1 << 27
+	ColorEditFlagsInputRGB ColorEditFlags = 1 << 27
 	// ColorEditFlagsInputHSV enables input and output data in HSV format.
-	ColorEditFlagsInputHSV = 1 << 28
+	ColorEditFlagsInputHSV ColorEditFlags = 1 << 28
 )
 
 // ColorEdit3 calls ColorEdit3V(label, col, 0).
@@ -728,7 +731,7 @@ func ColorEdit3(label string, col *[3]float32) bool {
 }
 
 // ColorEdit3V will show a clickable little square which will open a color picker window for 3D vector (rgb format).
-func ColorEdit3V(label string, col *[3]float32, flags int) bool {
+func ColorEdit3V(label string, col *[3]float32, flags ColorEditFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	ccol := (*C.float)(&col[0])
@@ -741,61 +744,64 @@ func ColorEdit4(label string, col *[4]float32) bool {
 }
 
 // ColorEdit4V will show a clickable little square which will open a color picker window for 4D vector (rgba format).
-func ColorEdit4V(label string, col *[4]float32, flags int) bool {
+func ColorEdit4V(label string, col *[4]float32, flags ColorEditFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	ccol := (*C.float)(&col[0])
 	return C.iggColorEdit4(labelArg, ccol, C.int(flags)) != 0
 }
 
+// ColorPickerFlags for ColorPicker3V(), etc.
+type ColorPickerFlags int
+
 const (
 	// ColorPickerFlagsNone default = 0
-	ColorPickerFlagsNone = 0
+	ColorPickerFlagsNone ColorPickerFlags = 0
 	// ColorPickerFlagsNoPicker disables picker when clicking on colored square.
-	ColorPickerFlagsNoPicker = 1 << 2
+	ColorPickerFlagsNoPicker ColorPickerFlags = 1 << 2
 	// ColorPickerFlagsNoOptions disables toggling options menu when right-clicking on inputs/small preview.
-	ColorPickerFlagsNoOptions = 1 << 3
+	ColorPickerFlagsNoOptions ColorPickerFlags = 1 << 3
 	// ColorPickerFlagsNoAlpha ignoreс Alpha component (read 3 components from the input pointer).
-	ColorPickerFlagsNoAlpha = 1 << 1
+	ColorPickerFlagsNoAlpha ColorPickerFlags = 1 << 1
 	// ColorPickerFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs)
-	ColorPickerFlagsNoSmallPreview = 1 << 4
+	ColorPickerFlagsNoSmallPreview ColorPickerFlags = 1 << 4
 	// ColorPickerFlagsNoInputs disables inputs sliders/text widgets (e.g. to show only the small preview colored square).
-	ColorPickerFlagsNoInputs = 1 << 5
+	ColorPickerFlagsNoInputs ColorPickerFlags = 1 << 5
 	// ColorPickerFlagsNoTooltip disables tooltip when hovering the preview.
-	ColorPickerFlagsNoTooltip = 1 << 6
+	ColorPickerFlagsNoTooltip ColorPickerFlags = 1 << 6
 	// ColorPickerFlagsNoLabel disables display of inline text label (the label is still forwarded to the tooltip and picker).
-	ColorPickerFlagsNoLabel = 1 << 7
+	ColorPickerFlagsNoLabel ColorPickerFlags = 1 << 7
 	// ColorPickerFlagsNoSidePreview disables bigger color preview on right side of the picker, use small colored square preview instead.
-	ColorPickerFlagsNoSidePreview = 1 << 8
+	ColorPickerFlagsNoSidePreview ColorPickerFlags = 1 << 8
 
 	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions().
 	// The idea is that you probably don't want to override them in most of your calls, let the user choose and/or call
 	// SetColorPickerOptions() during startup.
 
 	// ColorPickerFlagsAlphaBar shows vertical alpha bar/gradient in picker.
-	ColorPickerFlagsAlphaBar = 1 << 16
+	ColorPickerFlagsAlphaBar ColorPickerFlags = 1 << 16
 	// ColorPickerFlagsAlphaPreview displays preview as a transparent color over a checkerboard, instead of opaque.
-	ColorPickerFlagsAlphaPreview = 1 << 17
+	ColorPickerFlagsAlphaPreview ColorPickerFlags = 1 << 17
 	// ColorPickerFlagsAlphaPreviewHalf displays half opaque / half checkerboard, instead of opaque.
-	ColorPickerFlagsAlphaPreviewHalf = 1 << 18
+	ColorPickerFlagsAlphaPreviewHalf ColorPickerFlags = 1 << 18
 	// ColorPickerFlagsRGB sets the format as RGB
-	ColorPickerFlagsRGB = 1 << 20
+	ColorPickerFlagsRGB ColorPickerFlags = 1 << 20
 	// ColorPickerFlagsHSV sets the format as HSV
-	ColorPickerFlagsHSV = 1 << 21
+	ColorPickerFlagsHSV ColorPickerFlags = 1 << 21
 	// ColorPickerFlagsHEX sets the format as HEX
-	ColorPickerFlagsHEX = 1 << 22
+	ColorPickerFlagsHEX ColorPickerFlags = 1 << 22
 	// ColorPickerFlagsUint8 _display_ values formatted as 0..255.
-	ColorPickerFlagsUint8 = 1 << 23
+	ColorPickerFlagsUint8 ColorPickerFlags = 1 << 23
 	// ColorPickerFlagsFloat _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.
-	ColorPickerFlagsFloat = 1 << 24
+	ColorPickerFlagsFloat ColorPickerFlags = 1 << 24
 	// ColorPickerFlagsPickerHueBar bar for Hue, rectangle for Sat/Value.
-	ColorPickerFlagsPickerHueBar = 1 << 25
+	ColorPickerFlagsPickerHueBar ColorPickerFlags = 1 << 25
 	// ColorPickerFlagsPickerHueWheel wheel for Hue, triangle for Sat/Value.
-	ColorPickerFlagsPickerHueWheel = 1 << 26
+	ColorPickerFlagsPickerHueWheel ColorPickerFlags = 1 << 26
 	// ColorPickerFlagsInputRGB enables input and output data in RGB format.
-	ColorPickerFlagsInputRGB = 1 << 27
+	ColorPickerFlagsInputRGB ColorPickerFlags = 1 << 27
 	// ColorPickerFlagsInputHSV enables input and output data in HSV format.
-	ColorPickerFlagsInputHSV = 1 << 28
+	ColorPickerFlagsInputHSV ColorPickerFlags = 1 << 28
 )
 
 // ColorPicker3 calls ColorPicker3V(label, col, 0).
@@ -804,7 +810,7 @@ func ColorPicker3(label string, col *[3]float32) bool {
 }
 
 // ColorPicker3V will show directly a color picker control for editing a color in 3D vector (rgb format).
-func ColorPicker3V(label string, col *[3]float32, flags int) bool {
+func ColorPicker3V(label string, col *[3]float32, flags ColorPickerFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	ccol := (*C.float)(&col[0])
@@ -817,7 +823,7 @@ func ColorPicker4(label string, col *[4]float32) bool {
 }
 
 // ColorPicker4V will show directly a color picker control for editing a color in 4D vector (rgba format).
-func ColorPicker4V(label string, col *[4]float32, flags int) bool {
+func ColorPicker4V(label string, col *[4]float32, flags ColorPickerFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	ccol := (*C.float)(&col[0])

--- a/Widgets.go
+++ b/Widgets.go
@@ -185,13 +185,13 @@ const (
 	// SliderFlagsNone is no flag applied.
 	SliderFlagsNone SliderFlags = 0
 	// SliderFlagsAlwaysClamp clamps value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds.
-	SliderFlagsAlwaysClamp SliderFlags = 1 << 0
+	SliderFlagsAlwaysClamp SliderFlags = 1 << 4
 	// SliderFlagsLogarithmic makes the widget logarithmic (linear otherwise). Consider using SliderFlagNoRoundToFormat with this if using a format-string with small amount of digits.
-	SliderFlagsLogarithmic SliderFlags = 1 << 1
+	SliderFlagsLogarithmic SliderFlags = 1 << 5
 	// SliderFlagsNoRoundToFormat disables rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits).
-	SliderFlagsNoRoundToFormat SliderFlags = 1 << 2
+	SliderFlagsNoRoundToFormat SliderFlags = 1 << 6
 	// SliderFlagsNoInput disables CTRL+Click or Enter key allowing to input text directly into the widget.
-	SliderFlagsNoInput SliderFlags = 1 << 3
+	SliderFlagsNoInput SliderFlags = 1 << 7
 )
 
 // DragFloatV creates a draggable slider for floats.

--- a/Widgets.go
+++ b/Widgets.go
@@ -41,13 +41,13 @@ type ButtonFlags int
 
 const (
 	// ButtonFlagsNone is no flag applied.
-	ButtonFlagsNone = 0
+	ButtonFlagsNone ButtonFlags = 0
 	// ButtonFlagsMouseButtonLeft reacts on left mouse button (default).
-	ButtonFlagsMouseButtonLeft = 1 << 0
+	ButtonFlagsMouseButtonLeft ButtonFlags = 1 << iota
 	// ButtonFlagsMouseButtonRight reacts on right mouse button.
-	ButtonFlagsMouseButtonRight = 1 << 1
+	ButtonFlagsMouseButtonRight
 	// ButtonFlagsMouseButtonMiddle reacts on center mouse button.
-	ButtonFlagsMouseButtonMiddle = 1 << 2
+	ButtonFlagsMouseButtonMiddle
 )
 
 // InvisibleButtonV returns true if it is clicked.

--- a/Widgets.go
+++ b/Widgets.go
@@ -133,11 +133,11 @@ func ProgressBar(fraction float32) {
 	ProgressBarV(fraction, Vec2{X: -math.SmallestNonzeroFloat32, Y: 0}, "")
 }
 
-// ComboFlags for BeginComboV()
+// ComboFlags for BeginComboV().
 type ComboFlags int
 
 const (
-	// ComboFlagsNone default = 0
+	// ComboFlagsNone default = 0.
 	ComboFlagsNone ComboFlags = 0
 	// ComboFlagsPopupAlignLeft aligns the popup toward the left by default.
 	ComboFlagsPopupAlignLeft ComboFlags = 1 << 0
@@ -188,9 +188,9 @@ const (
 	SliderFlagsAlwaysClamp SliderFlags = 1 << 0
 	// SliderFlagsLogarithmic makes the widget logarithmic (linear otherwise). Consider using SliderFlagNoRoundToFormat with this if using a format-string with small amount of digits.
 	SliderFlagsLogarithmic SliderFlags = 1 << 1
-	// SliderFlagsNoRoundToFormat disables rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits)
+	// SliderFlagsNoRoundToFormat disables rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits).
 	SliderFlagsNoRoundToFormat SliderFlags = 1 << 2
-	// SliderFlagsNoInput disables CTRL+Click or Enter key allowing to input text directly into the widget
+	// SliderFlagsNoInput disables CTRL+Click or Enter key allowing to input text directly into the widget.
 	SliderFlagsNoInput SliderFlags = 1 << 3
 )
 
@@ -518,9 +518,9 @@ type InputTextFlags int
 const (
 	// InputTextFlagsNone sets everything default.
 	InputTextFlagsNone InputTextFlags = 0
-	// InputTextFlagsCharsDecimal allows 0123456789.+-
+	// InputTextFlagsCharsDecimal allows 0123456789.+-.
 	InputTextFlagsCharsDecimal InputTextFlags = 1 << 0
-	// InputTextFlagsCharsHexadecimal allow 0123456789ABCDEFabcdef
+	// InputTextFlagsCharsHexadecimal allow 0123456789ABCDEFabcdef.
 	InputTextFlagsCharsHexadecimal InputTextFlags = 1 << 1
 	// InputTextFlagsCharsUppercase turns a..z into A..Z.
 	InputTextFlagsCharsUppercase InputTextFlags = 1 << 2
@@ -559,7 +559,7 @@ const (
 	InputTextFlagsCharsScientific InputTextFlags = 1 << 17
 	// inputTextFlagsCallbackResize for callback on buffer capacity change requests.
 	inputTextFlagsCallbackResize InputTextFlags = 1 << 18
-	// ImGuiInputTextFlagsCallbackEdit for callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)
+	// ImGuiInputTextFlagsCallbackEdit for callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active).
 	ImGuiInputTextFlagsCallbackEdit InputTextFlags = 1 << 19
 )
 
@@ -668,7 +668,7 @@ func InputInt(label string, value *int32) bool {
 type ColorEditFlags int
 
 const (
-	// ColorEditFlagsNone default = 0
+	// ColorEditFlagsNone default = 0.
 	ColorEditFlagsNone ColorEditFlags = 0
 	// ColorEditFlagsNoAlpha ignores Alpha component (read 3 components from the input pointer).
 	ColorEditFlagsNoAlpha ColorEditFlags = 1 << 1
@@ -676,7 +676,7 @@ const (
 	ColorEditFlagsNoPicker ColorEditFlags = 1 << 2
 	// ColorEditFlagsNoOptions disables toggling options menu when right-clicking on inputs/small preview.
 	ColorEditFlagsNoOptions ColorEditFlags = 1 << 3
-	// ColorEditFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs)
+	// ColorEditFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs).
 	ColorEditFlagsNoSmallPreview ColorEditFlags = 1 << 4
 	// ColorEditFlagsNoInputs disables inputs sliders/text widgets (e.g. to show only the small preview colored square).
 	ColorEditFlagsNoInputs ColorEditFlags = 1 << 5
@@ -688,7 +688,7 @@ const (
 	ColorEditFlagsNoSidePreview ColorEditFlags = 1 << 8
 	// ColorEditFlagsNoDragDrop disables drag and drop target. ColorButton: disable drag and drop source.
 	ColorEditFlagsNoDragDrop ColorEditFlags = 1 << 9
-	// ColorEditFlagsNoBorder disables border (which is enforced by default)
+	// ColorEditFlagsNoBorder disables border (which is enforced by default).
 	ColorEditFlagsNoBorder ColorEditFlags = 1 << 10
 
 	// User Options (right-click on widget to change some of them). You can set application defaults using SetColorEditOptions().
@@ -704,11 +704,11 @@ const (
 	// ColorEditFlagsHDR = (WIP) surrently only disable 0.0f..1.0f limits in RGBA edition.
 	// Note: you probably want to use ImGuiColorEditFlags_Float flag as well.
 	ColorEditFlagsHDR ColorEditFlags = 1 << 19
-	// ColorEditFlagsRGB sets the format as RGB
+	// ColorEditFlagsRGB sets the format as RGB.
 	ColorEditFlagsRGB ColorEditFlags = 1 << 20
-	// ColorEditFlagsHSV sets the format as HSV
+	// ColorEditFlagsHSV sets the format as HSV.
 	ColorEditFlagsHSV ColorEditFlags = 1 << 21
-	// ColorEditFlagsHEX sets the format as HEX
+	// ColorEditFlagsHEX sets the format as HEX.
 	ColorEditFlagsHEX ColorEditFlags = 1 << 22
 	// ColorEditFlagsUint8 _display_ values formatted as 0..255.
 	ColorEditFlagsUint8 ColorEditFlags = 1 << 23
@@ -755,7 +755,7 @@ func ColorEdit4V(label string, col *[4]float32, flags ColorEditFlags) bool {
 type ColorPickerFlags int
 
 const (
-	// ColorPickerFlagsNone default = 0
+	// ColorPickerFlagsNone default = 0.
 	ColorPickerFlagsNone ColorPickerFlags = 0
 	// ColorPickerFlagsNoPicker disables picker when clicking on colored square.
 	ColorPickerFlagsNoPicker ColorPickerFlags = 1 << 2
@@ -763,7 +763,7 @@ const (
 	ColorPickerFlagsNoOptions ColorPickerFlags = 1 << 3
 	// ColorPickerFlagsNoAlpha ignoreс Alpha component (read 3 components from the input pointer).
 	ColorPickerFlagsNoAlpha ColorPickerFlags = 1 << 1
-	// ColorPickerFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs)
+	// ColorPickerFlagsNoSmallPreview disables colored square preview next to the inputs. (e.g. to show only the inputs).
 	ColorPickerFlagsNoSmallPreview ColorPickerFlags = 1 << 4
 	// ColorPickerFlagsNoInputs disables inputs sliders/text widgets (e.g. to show only the small preview colored square).
 	ColorPickerFlagsNoInputs ColorPickerFlags = 1 << 5
@@ -784,11 +784,11 @@ const (
 	ColorPickerFlagsAlphaPreview ColorPickerFlags = 1 << 17
 	// ColorPickerFlagsAlphaPreviewHalf displays half opaque / half checkerboard, instead of opaque.
 	ColorPickerFlagsAlphaPreviewHalf ColorPickerFlags = 1 << 18
-	// ColorPickerFlagsRGB sets the format as RGB
+	// ColorPickerFlagsRGB sets the format as RGB.
 	ColorPickerFlagsRGB ColorPickerFlags = 1 << 20
-	// ColorPickerFlagsHSV sets the format as HSV
+	// ColorPickerFlagsHSV sets the format as HSV.
 	ColorPickerFlagsHSV ColorPickerFlags = 1 << 21
-	// ColorPickerFlagsHEX sets the format as HEX
+	// ColorPickerFlagsHEX sets the format as HEX.
 	ColorPickerFlagsHEX ColorPickerFlags = 1 << 22
 	// ColorPickerFlagsUint8 _display_ values formatted as 0..255.
 	ColorPickerFlagsUint8 ColorPickerFlags = 1 << 23
@@ -842,15 +842,15 @@ func CollapsingHeaderV(label string, flags TreeNodeFlags) bool {
 	return C.iggCollapsingHeader(labelArg, C.int(flags)) != 0
 }
 
-// TreeNodeFlags for TreeNodeV(), CollapsingHeaderV(), etc
+// TreeNodeFlags for TreeNodeV(), CollapsingHeaderV(), etc.
 type TreeNodeFlags int
 
 const (
-	// TreeNodeFlagsNone default = 0
+	// TreeNodeFlagsNone default = 0.
 	TreeNodeFlagsNone TreeNodeFlags = 0
 	// TreeNodeFlagsSelected draws as selected.
 	TreeNodeFlagsSelected TreeNodeFlags = 1 << 0
-	// TreeNodeFlagsFramed draws frame with background (e.g. for CollapsingHeader)
+	// TreeNodeFlagsFramed draws frame with background (e.g. for CollapsingHeader).
 	TreeNodeFlagsFramed TreeNodeFlags = 1 << 1
 	// TreeNodeFlagsAllowItemOverlap hit testing to allow subsequent widgets to overlap this one.
 	TreeNodeFlagsAllowItemOverlap TreeNodeFlags = 1 << 2
@@ -882,7 +882,7 @@ const (
 	// TreeNodeFlagsSpanFullWidth extends hit box to the left-most and right-most edges (bypass the indented area).
 	TreeNodeFlagsSpanFullWidth TreeNodeFlags = 1 << 12
 	// TreeNodeFlagsNavLeftJumpsBackHere (WIP) Nav: left direction may move to this TreeNode() from any of its child
-	// (items submitted between TreeNode and TreePop)
+	// (items submitted between TreeNode and TreePop).
 	TreeNodeFlagsNavLeftJumpsBackHere TreeNodeFlags = 1 << 13
 	// TreeNodeFlagsCollapsingHeader combines TreeNodeFlagsFramed and TreeNodeFlagsNoAutoOpenOnLog.
 	TreeNodeFlagsCollapsingHeader = TreeNodeFlagsFramed | TreeNodeFlagsNoTreePushOnOpen | TreeNodeFlagsNoAutoOpenOnLog
@@ -919,7 +919,7 @@ func TreeNodeToLabelSpacing() float32 {
 type SelectableFlags int
 
 const (
-	// SelectableFlagsNone default = 0
+	// SelectableFlagsNone default = 0.
 	SelectableFlagsNone SelectableFlags = 0
 	// SelectableFlagsDontClosePopups makes clicking the selectable not close any parent popup windows.
 	SelectableFlagsDontClosePopups SelectableFlags = 1 << 0
@@ -929,7 +929,7 @@ const (
 	SelectableFlagsAllowDoubleClick SelectableFlags = 1 << 2
 	// SelectableFlagsDisabled disallows selection and displays text in a greyed out color.
 	SelectableFlagsDisabled SelectableFlags = 1 << 3
-	// SelectableFlagsAllowItemOverlap hit testing to allow subsequent widgets to overlap this one (WIP)
+	// SelectableFlagsAllowItemOverlap hit testing to allow subsequent widgets to overlap this one (WIP).
 	SelectableFlagsAllowItemOverlap SelectableFlags = 1 << 4
 )
 
@@ -1221,29 +1221,29 @@ type TabBarFlags int
 const (
 	// TabBarFlagsNone default = 0.
 	TabBarFlagsNone TabBarFlags = 0
-	// TabBarFlagsReorderable Allow manually dragging tabs to re-order them + New tabs are appended at the end of list
+	// TabBarFlagsReorderable Allow manually dragging tabs to re-order them + New tabs are appended at the end of list.
 	TabBarFlagsReorderable TabBarFlags = 1 << 0
-	// TabBarFlagsAutoSelectNewTabs Automatically select new tabs when they appear
+	// TabBarFlagsAutoSelectNewTabs Automatically select new tabs when they appear.
 	TabBarFlagsAutoSelectNewTabs TabBarFlags = 1 << 1
-	// TabBarFlagsTabListPopupButton Disable buttons to open the tab list popup
+	// TabBarFlagsTabListPopupButton Disable buttons to open the tab list popup.
 	TabBarFlagsTabListPopupButton TabBarFlags = 1 << 2
 	// TabBarFlagsNoCloseWithMiddleMouseButton Disable behavior of closing tabs (that are submitted with p_open != NULL)
 	// with middle mouse button. You can still repro this behavior on user's side with if
 	// (IsItemHovered() && IsMouseClicked(2)) *p_open = false.
 	TabBarFlagsNoCloseWithMiddleMouseButton TabBarFlags = 1 << 3
 	// TabBarFlagsNoTabListScrollingButtons Disable scrolling buttons (apply when fitting policy is
-	// TabBarFlagsFittingPolicyScroll)
+	// TabBarFlagsFittingPolicyScroll).
 	TabBarFlagsNoTabListScrollingButtons TabBarFlags = 1 << 4
-	// TabBarFlagsNoTooltip Disable tooltips when hovering a tab
+	// TabBarFlagsNoTooltip Disable tooltips when hovering a tab.
 	TabBarFlagsNoTooltip TabBarFlags = 1 << 5
-	// TabBarFlagsFittingPolicyResizeDown Resize tabs when they don't fit
+	// TabBarFlagsFittingPolicyResizeDown Resize tabs when they don't fit.
 	TabBarFlagsFittingPolicyResizeDown TabBarFlags = 1 << 6
-	// TabBarFlagsFittingPolicyScroll Add scroll buttons when tabs don't fit
+	// TabBarFlagsFittingPolicyScroll Add scroll buttons when tabs don't fit.
 	TabBarFlagsFittingPolicyScroll TabBarFlags = 1 << 7
 	// TabBarFlagsFittingPolicyMask combines
-	// TabBarFlagsFittingPolicyResizeDown and TabBarFlagsFittingPolicyScroll
+	// TabBarFlagsFittingPolicyResizeDown and TabBarFlagsFittingPolicyScroll.
 	TabBarFlagsFittingPolicyMask = TabBarFlagsFittingPolicyResizeDown | TabBarFlagsFittingPolicyScroll
-	// TabBarFlagsFittingPolicyDefault alias for TabBarFlagsFittingPolicyResizeDown
+	// TabBarFlagsFittingPolicyDefault alias for TabBarFlagsFittingPolicyResizeDown.
 	TabBarFlagsFittingPolicyDefault = TabBarFlagsFittingPolicyResizeDown
 )
 
@@ -1269,27 +1269,27 @@ func EndTabBar() {
 type TabItemFlags int
 
 const (
-	// TabItemFlagsNone default = 0
+	// TabItemFlagsNone default = 0.
 	TabItemFlagsNone TabItemFlags = 0
 	// TabItemFlagsUnsavedDocument Append '*' to title without affecting the ID, as a convenience to avoid using the
 	// ### operator. Also: tab is selected on closure and closure is deferred by one frame to allow code to undo it
 	// without flicker.
 	TabItemFlagsUnsavedDocument TabItemFlags = 1 << 0
-	// TabItemFlagsSetSelected Trigger flag to programmatically make the tab selected when calling BeginTabItem()
+	// TabItemFlagsSetSelected Trigger flag to programmatically make the tab selected when calling BeginTabItem().
 	TabItemFlagsSetSelected TabItemFlags = 1 << 1
 	// TabItemFlagsNoCloseWithMiddleMouseButton  Disable behavior of closing tabs (that are submitted with
 	// p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if
 	// (IsItemHovered() && IsMouseClicked(2)) *p_open = false.
 	TabItemFlagsNoCloseWithMiddleMouseButton TabItemFlags = 1 << 2
-	// TabItemFlagsNoPushID Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem()
+	// TabItemFlagsNoPushID Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem().
 	TabItemFlagsNoPushID TabItemFlags = 1 << 3
-	// TabItemFlagsNoTooltip Disable tooltip for the given tab
+	// TabItemFlagsNoTooltip Disable tooltip for the given tab.
 	TabItemFlagsNoTooltip TabItemFlags = 1 << 4
-	// TabItemFlagsNoReorder Disable reordering this tab or having another tab cross over this tab
+	// TabItemFlagsNoReorder Disable reordering this tab or having another tab cross over this tab.
 	TabItemFlagsNoReorder TabItemFlags = 1 << 5
-	// TabItemFlagsLeading Enforce the tab position to the left of the tab bar (after the tab list popup button)
+	// TabItemFlagsLeading Enforce the tab position to the left of the tab bar (after the tab list popup button).
 	TabItemFlagsLeading TabItemFlags = 1 << 6
-	// TabItemFlagsTrailing Enforce the tab position to the right of the tab bar (before the scrolling buttons)
+	// TabItemFlagsTrailing Enforce the tab position to the right of the tab bar (before the scrolling buttons).
 	TabItemFlagsTrailing TabItemFlags = 1 << 7
 )
 

--- a/Widgets.go
+++ b/Widgets.go
@@ -827,57 +827,60 @@ func CollapsingHeader(label string) bool {
 }
 
 // CollapsingHeaderV adds a collapsing header with TreeNode flags.
-func CollapsingHeaderV(label string, flags int) bool {
+func CollapsingHeaderV(label string, flags TreeNodeFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	return C.iggCollapsingHeader(labelArg, C.int(flags)) != 0
 }
 
+// TreeNodeFlags for TreeNodeV(), CollapsingHeaderV(), etc
+type TreeNodeFlags int
+
 const (
 	// TreeNodeFlagsNone default = 0
-	TreeNodeFlagsNone = 0
+	TreeNodeFlagsNone TreeNodeFlags = 0
 	// TreeNodeFlagsSelected draws as selected.
-	TreeNodeFlagsSelected = 1 << 0
+	TreeNodeFlagsSelected TreeNodeFlags = 1 << 0
 	// TreeNodeFlagsFramed draws frame with background (e.g. for CollapsingHeader)
-	TreeNodeFlagsFramed = 1 << 1
+	TreeNodeFlagsFramed TreeNodeFlags = 1 << 1
 	// TreeNodeFlagsAllowItemOverlap hit testing to allow subsequent widgets to overlap this one.
-	TreeNodeFlagsAllowItemOverlap = 1 << 2
+	TreeNodeFlagsAllowItemOverlap TreeNodeFlags = 1 << 2
 	// TreeNodeFlagsNoTreePushOnOpen doesn't do a TreePush() when open
 	// (e.g. for CollapsingHeader) = no extra indent nor pushing on ID stack.
-	TreeNodeFlagsNoTreePushOnOpen = 1 << 3
+	TreeNodeFlagsNoTreePushOnOpen TreeNodeFlags = 1 << 3
 	// TreeNodeFlagsNoAutoOpenOnLog doesn't automatically and temporarily open node when Logging is active
 	// (by default logging will automatically open tree nodes).
-	TreeNodeFlagsNoAutoOpenOnLog = 1 << 4
+	TreeNodeFlagsNoAutoOpenOnLog TreeNodeFlags = 1 << 4
 	// TreeNodeFlagsDefaultOpen defaults node to be open.
-	TreeNodeFlagsDefaultOpen = 1 << 5
+	TreeNodeFlagsDefaultOpen TreeNodeFlags = 1 << 5
 	// TreeNodeFlagsOpenOnDoubleClick needs double-click to open node.
-	TreeNodeFlagsOpenOnDoubleClick = 1 << 6
+	TreeNodeFlagsOpenOnDoubleClick TreeNodeFlags = 1 << 6
 	// TreeNodeFlagsOpenOnArrow opens only when clicking on the arrow part.
 	// If TreeNodeFlagsOpenOnDoubleClick is also set, single-click arrow or double-click all box to open.
-	TreeNodeFlagsOpenOnArrow = 1 << 7
+	TreeNodeFlagsOpenOnArrow TreeNodeFlags = 1 << 7
 	// TreeNodeFlagsLeaf allows no collapsing, no arrow (use as a convenience for leaf nodes).
-	TreeNodeFlagsLeaf = 1 << 8
+	TreeNodeFlagsLeaf TreeNodeFlags = 1 << 8
 	// TreeNodeFlagsBullet displays a bullet instead of an arrow.
-	TreeNodeFlagsBullet = 1 << 9
+	TreeNodeFlagsBullet TreeNodeFlags = 1 << 9
 	// TreeNodeFlagsFramePadding uses FramePadding (even for an unframed text node) to
 	// vertically align text baseline to regular widget height. Equivalent to calling AlignTextToFramePadding().
-	TreeNodeFlagsFramePadding = 1 << 10
+	TreeNodeFlagsFramePadding TreeNodeFlags = 1 << 10
 	// TreeNodeFlagsSpanAvailWidth extends hit box to the right-most edge, even if not framed.
 	// This is not the default in order to allow adding other items on the same line.
 	// In the future we may refactor the hit system to be front-to-back, allowing natural overlaps
 	// and then this can become the default.
-	TreeNodeFlagsSpanAvailWidth = 1 << 11
+	TreeNodeFlagsSpanAvailWidth TreeNodeFlags = 1 << 11
 	// TreeNodeFlagsSpanFullWidth extends hit box to the left-most and right-most edges (bypass the indented area).
-	TreeNodeFlagsSpanFullWidth = 1 << 12
+	TreeNodeFlagsSpanFullWidth TreeNodeFlags = 1 << 12
 	// TreeNodeFlagsNavLeftJumpsBackHere (WIP) Nav: left direction may move to this TreeNode() from any of its child
 	// (items submitted between TreeNode and TreePop)
-	TreeNodeFlagsNavLeftJumpsBackHere = 1 << 13
+	TreeNodeFlagsNavLeftJumpsBackHere TreeNodeFlags = 1 << 13
 	// TreeNodeFlagsCollapsingHeader combines TreeNodeFlagsFramed and TreeNodeFlagsNoAutoOpenOnLog.
 	TreeNodeFlagsCollapsingHeader = TreeNodeFlagsFramed | TreeNodeFlagsNoTreePushOnOpen | TreeNodeFlagsNoAutoOpenOnLog
 )
 
 // TreeNodeV returns true if the tree branch is to be rendered. Call TreePop() in this case.
-func TreeNodeV(label string, flags int) bool {
+func TreeNodeV(label string, flags TreeNodeFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	return C.iggTreeNode(labelArg, C.int(flags)) != 0

--- a/Widgets.go
+++ b/Widgets.go
@@ -906,26 +906,29 @@ func TreeNodeToLabelSpacing() float32 {
 	return float32(C.iggGetTreeNodeToLabelSpacing())
 }
 
+// SelectableFlags for SelectableV().
+type SelectableFlags int
+
 const (
 	// SelectableFlagsNone default = 0
-	SelectableFlagsNone = 0
+	SelectableFlagsNone SelectableFlags = 0
 	// SelectableFlagsDontClosePopups makes clicking the selectable not close any parent popup windows.
-	SelectableFlagsDontClosePopups = 1 << 0
+	SelectableFlagsDontClosePopups SelectableFlags = 1 << 0
 	// SelectableFlagsSpanAllColumns allows the selectable frame to span all columns (text will still fit in current column).
-	SelectableFlagsSpanAllColumns = 1 << 1
+	SelectableFlagsSpanAllColumns SelectableFlags = 1 << 1
 	// SelectableFlagsAllowDoubleClick generates press events on double clicks too.
-	SelectableFlagsAllowDoubleClick = 1 << 2
+	SelectableFlagsAllowDoubleClick SelectableFlags = 1 << 2
 	// SelectableFlagsDisabled disallows selection and displays text in a greyed out color.
-	SelectableFlagsDisabled = 1 << 3
+	SelectableFlagsDisabled SelectableFlags = 1 << 3
 	// SelectableFlagsAllowItemOverlap hit testing to allow subsequent widgets to overlap this one (WIP)
-	SelectableFlagsAllowItemOverlap = 1 << 4
+	SelectableFlagsAllowItemOverlap SelectableFlags = 1 << 4
 )
 
 // SelectableV returns true if the user clicked it, so you can modify your selection state.
 // flags are the SelectableFlags to apply.
 // size.x==0.0: use remaining width, size.x>0.0: specify width.
 // size.y==0.0: use label height, size.y>0.0: specify height.
-func SelectableV(label string, selected bool, flags int, size Vec2) bool {
+func SelectableV(label string, selected bool, flags SelectableFlags, size Vec2) bool {
 	labelArg, labelFin := wrapString(label)
 	defer labelFin()
 	sizeArg, _ := size.wrapped()

--- a/Window.go
+++ b/Window.go
@@ -20,7 +20,7 @@ func ShowUserGuide() {
 type WindowFlags int
 
 const (
-	// WindowFlagsNone default = 0
+	// WindowFlagsNone default = 0.
 	WindowFlagsNone WindowFlags = 0
 	// WindowFlagsNoTitleBar disables title-bar.
 	WindowFlagsNoTitleBar WindowFlags = 1 << 0
@@ -65,7 +65,7 @@ const (
 	// WindowFlagsNoNavInputs has no gamepad/keyboard navigation within the window.
 	WindowFlagsNoNavInputs WindowFlags = 1 << 18
 	// WindowFlagsNoNavFocus has no focusing toward this window with gamepad/keyboard navigation
-	// (e.g. skipped by CTRL+TAB)
+	// (e.g. skipped by CTRL+TAB).
 	WindowFlagsNoNavFocus WindowFlags = 1 << 19
 	// WindowFlagsUnsavedDocument appends '*' to title without affecting the ID, as a convenience to avoid using the
 	// ### operator. When used in a tab/docking context, tab is selected on closure and closure is deferred by one
@@ -277,13 +277,13 @@ func SetNextItemWidth(width float32) {
 type ItemFlags int
 
 const (
-	// ItemFlagsNone default = 0
+	// ItemFlagsNone default = 0.
 	ItemFlagsNone ItemFlags = 0
 	// ItemFlagsNoTabStop has no tab stop.
 	ItemFlagsNoTabStop ItemFlags = 1 << 0
 	// ItemFlagsButtonRepeat will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings.
 	ItemFlagsButtonRepeat ItemFlags = 1 << 1
-	// ItemFlagsDisabled [BETA] disable interactions but doesn't affect visuals yet. See github.com/ocornut/imgui/issues/211
+	// ItemFlagsDisabled [BETA] disable interactions but doesn't affect visuals yet. See github.com/ocornut/imgui/issues/211.
 	ItemFlagsDisabled ItemFlags = 1 << 2
 	// ItemFlagsNoNav has no nav.
 	ItemFlagsNoNav ItemFlags = 1 << 3
@@ -294,7 +294,7 @@ const (
 	// ItemFlagsMixedValue [BETA] represent a mixed/indeterminate value, generally multi-selection where values differ.
 	// Currently only supported by Checkbox() (later should support all sorts of widgets).
 	ItemFlagsMixedValue ItemFlags = 1 << 6
-	// ItemFlagsDefault default = 0
+	// ItemFlagsDefault default = 0.
 	ItemFlagsDefault ItemFlags = 0
 )
 

--- a/Window.go
+++ b/Window.go
@@ -16,58 +16,61 @@ func ShowUserGuide() {
 	C.iggShowUserGuide()
 }
 
+// WindowFlags for BeginV(), etc.
+type WindowFlags int
+
 const (
 	// WindowFlagsNone default = 0
-	WindowFlagsNone = 0
+	WindowFlagsNone WindowFlags = 0
 	// WindowFlagsNoTitleBar disables title-bar.
-	WindowFlagsNoTitleBar = 1 << 0
+	WindowFlagsNoTitleBar WindowFlags = 1 << 0
 	// WindowFlagsNoResize disables user resizing with the lower-right grip.
-	WindowFlagsNoResize = 1 << 1
+	WindowFlagsNoResize WindowFlags = 1 << 1
 	// WindowFlagsNoMove disables user moving the window.
-	WindowFlagsNoMove = 1 << 2
+	WindowFlagsNoMove WindowFlags = 1 << 2
 	// WindowFlagsNoScrollbar disables scrollbars. Window can still scroll with mouse or programmatically.
-	WindowFlagsNoScrollbar = 1 << 3
+	WindowFlagsNoScrollbar WindowFlags = 1 << 3
 	// WindowFlagsNoScrollWithMouse disables user vertically scrolling with mouse wheel. On child window, mouse wheel
 	// will be forwarded to the parent unless NoScrollbar is also set.
-	WindowFlagsNoScrollWithMouse = 1 << 4
+	WindowFlagsNoScrollWithMouse WindowFlags = 1 << 4
 	// WindowFlagsNoCollapse disables user collapsing window by double-clicking on it.
-	WindowFlagsNoCollapse = 1 << 5
+	WindowFlagsNoCollapse WindowFlags = 1 << 5
 	// WindowFlagsAlwaysAutoResize resizes every window to its content every frame.
-	WindowFlagsAlwaysAutoResize = 1 << 6
+	WindowFlagsAlwaysAutoResize WindowFlags = 1 << 6
 	// WindowFlagsNoBackground disables drawing background color (WindowBg, etc.) and outside border. Similar as using
 	// SetNextWindowBgAlpha(0.0f).
-	WindowFlagsNoBackground = 1 << 7
+	WindowFlagsNoBackground WindowFlags = 1 << 7
 	// WindowFlagsNoSavedSettings will never load/save settings in .ini file.
-	WindowFlagsNoSavedSettings = 1 << 8
+	WindowFlagsNoSavedSettings WindowFlags = 1 << 8
 	// WindowFlagsNoMouseInputs disables catching mouse, hovering test with pass through.
-	WindowFlagsNoMouseInputs = 1 << 9
+	WindowFlagsNoMouseInputs WindowFlags = 1 << 9
 	// WindowFlagsMenuBar has a menu-bar.
-	WindowFlagsMenuBar = 1 << 10
+	WindowFlagsMenuBar WindowFlags = 1 << 10
 	// WindowFlagsHorizontalScrollbar allows horizontal scrollbar to appear (off by default). You may use
 	// SetNextWindowContentSize(ImVec2(width,0.0f)); prior to calling Begin() to specify width. Read code in imgui_demo
 	// in the "Horizontal Scrolling" section.
-	WindowFlagsHorizontalScrollbar = 1 << 11
+	WindowFlagsHorizontalScrollbar WindowFlags = 1 << 11
 	// WindowFlagsNoFocusOnAppearing disables taking focus when transitioning from hidden to visible state.
-	WindowFlagsNoFocusOnAppearing = 1 << 12
+	WindowFlagsNoFocusOnAppearing WindowFlags = 1 << 12
 	// WindowFlagsNoBringToFrontOnFocus disables bringing window to front when taking focus. e.g. clicking on it or
 	// programmatically giving it focus.
-	WindowFlagsNoBringToFrontOnFocus = 1 << 13
+	WindowFlagsNoBringToFrontOnFocus WindowFlags = 1 << 13
 	// WindowFlagsAlwaysVerticalScrollbar always shows vertical scrollbar, even if ContentSize.y < Size.y .
-	WindowFlagsAlwaysVerticalScrollbar = 1 << 14
+	WindowFlagsAlwaysVerticalScrollbar WindowFlags = 1 << 14
 	// WindowFlagsAlwaysHorizontalScrollbar always shows horizontal scrollbar, even if ContentSize.x < Size.x .
-	WindowFlagsAlwaysHorizontalScrollbar = 1 << 15
+	WindowFlagsAlwaysHorizontalScrollbar WindowFlags = 1 << 15
 	// WindowFlagsAlwaysUseWindowPadding ensures child windows without border uses style.WindowPadding (ignored by
 	// default for non-bordered child windows, because more convenient).
-	WindowFlagsAlwaysUseWindowPadding = 1 << 16
+	WindowFlagsAlwaysUseWindowPadding WindowFlags = 1 << 16
 	// WindowFlagsNoNavInputs has no gamepad/keyboard navigation within the window.
-	WindowFlagsNoNavInputs = 1 << 18
+	WindowFlagsNoNavInputs WindowFlags = 1 << 18
 	// WindowFlagsNoNavFocus has no focusing toward this window with gamepad/keyboard navigation
 	// (e.g. skipped by CTRL+TAB)
-	WindowFlagsNoNavFocus = 1 << 19
+	WindowFlagsNoNavFocus WindowFlags = 1 << 19
 	// WindowFlagsUnsavedDocument appends '*' to title without affecting the ID, as a convenience to avoid using the
 	// ### operator. When used in a tab/docking context, tab is selected on closure and closure is deferred by one
 	// frame to allow code to cancel the closure (with a confirmation popup, etc.) without flicker.
-	WindowFlagsUnsavedDocument = 1 << 20
+	WindowFlagsUnsavedDocument WindowFlags = 1 << 20
 
 	// WindowFlagsNoNav combines WindowFlagsNoNavInputs and WindowFlagsNoNavFocus.
 	WindowFlagsNoNav = WindowFlagsNoNavInputs | WindowFlagsNoNavFocus
@@ -84,7 +87,7 @@ const (
 //
 // Returns false if the window is currently not visible.
 // Regardless of the return value, End() must be called for each call to Begin().
-func BeginV(id string, open *bool, flags int) bool {
+func BeginV(id string, open *bool, flags WindowFlags) bool {
 	idArg, idFin := wrapString(id)
 	defer idFin()
 	openArg, openFin := wrapBool(open)
@@ -105,7 +108,7 @@ func End() {
 
 // BeginChildV pushes a new child to the stack and starts appending to it.
 // flags are the WindowFlags to apply.
-func BeginChildV(id string, size Vec2, border bool, flags int) bool {
+func BeginChildV(id string, size Vec2, border bool, flags WindowFlags) bool {
 	idArg, idFin := wrapString(id)
 	defer idFin()
 	sizeArg, _ := size.wrapped()

--- a/Window.go
+++ b/Window.go
@@ -345,11 +345,11 @@ const (
 	// ViewportFlagsNone default = 0.
 	ViewportFlagsNone ViewportFlags = 0
 	// ViewportFlagsIsPlatformWindow represents a Platform Window.
-	ViewportFlagsIsPlatformWindow = 1 << 0
+	ViewportFlagsIsPlatformWindow ViewportFlags = 1 << iota
 	// ViewportFlagsIsPlatformMonitor represents a Platform Monitor (unused yet).
-	ViewportFlagsIsPlatformMonitor = 1 << 1
+	ViewportFlagsIsPlatformMonitor
 	// ViewportFlagsOwnedByApp Platform Window: is created/managed by the application (rather than a dear imgui backend).
-	ViewportFlagsOwnedByApp = 1 << 2
+	ViewportFlagsOwnedByApp
 )
 
 // MainViewport returns primary/default viewport.

--- a/Window.go
+++ b/Window.go
@@ -273,31 +273,33 @@ func SetNextItemWidth(width float32) {
 	C.iggSetNextItemWidth(C.float(width))
 }
 
+// ItemFlags for PushItemFlag().
+type ItemFlags int
+
 const (
 	// ItemFlagsNone default = 0
-	ItemFlagsNone = 0
+	ItemFlagsNone ItemFlags = 0
 	// ItemFlagsNoTabStop has no tab stop.
-	ItemFlagsNoTabStop = 1 << 0
+	ItemFlagsNoTabStop ItemFlags = 1 << 0
 	// ItemFlagsButtonRepeat will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings.
-	ItemFlagsButtonRepeat = 1 << 1
+	ItemFlagsButtonRepeat ItemFlags = 1 << 1
 	// ItemFlagsDisabled [BETA] disable interactions but doesn't affect visuals yet. See github.com/ocornut/imgui/issues/211
-	ItemFlagsDisabled = 1 << 2
+	ItemFlagsDisabled ItemFlags = 1 << 2
 	// ItemFlagsNoNav has no nav.
-	ItemFlagsNoNav = 1 << 3
+	ItemFlagsNoNav ItemFlags = 1 << 3
 	// ItemFlagsNoNavDefaultFocus has no nav default focus.
-	ItemFlagsNoNavDefaultFocus = 1 << 4
+	ItemFlagsNoNavDefaultFocus ItemFlags = 1 << 4
 	// ItemFlagsSelectableDontClosePopup automatically closes current Popup window.
-	ItemFlagsSelectableDontClosePopup = 1 << 5
+	ItemFlagsSelectableDontClosePopup ItemFlags = 1 << 5
 	// ItemFlagsMixedValue [BETA] represent a mixed/indeterminate value, generally multi-selection where values differ.
 	// Currently only supported by Checkbox() (later should support all sorts of widgets).
-	ItemFlagsMixedValue = 1 << 6
+	ItemFlagsMixedValue ItemFlags = 1 << 6
 	// ItemFlagsDefault default = 0
-	ItemFlagsDefault = 0
+	ItemFlagsDefault ItemFlags = 0
 )
 
 // PushItemFlag changes flags in the existing options for the next items until PopItemFlag() is called.
-// The integer of options is a bitfield of ItemFlags* combinations.
-func PushItemFlag(options int, enabled bool) {
+func PushItemFlag(options ItemFlags, enabled bool) {
 	C.iggPushItemFlag(C.int(options), castBool(enabled))
 }
 

--- a/Window.go
+++ b/Window.go
@@ -345,11 +345,11 @@ const (
 	// ViewportFlagsNone default = 0.
 	ViewportFlagsNone ViewportFlags = 0
 	// ViewportFlagsIsPlatformWindow represents a Platform Window.
-	ViewportFlagsIsPlatformWindow ViewportFlags = 1 << iota
+	ViewportFlagsIsPlatformWindow ViewportFlags = 1 << 0
 	// ViewportFlagsIsPlatformMonitor represents a Platform Monitor (unused yet).
-	ViewportFlagsIsPlatformMonitor
+	ViewportFlagsIsPlatformMonitor ViewportFlags = 1 << 1
 	// ViewportFlagsOwnedByApp Platform Window: is created/managed by the application (rather than a dear imgui backend).
-	ViewportFlagsOwnedByApp
+	ViewportFlagsOwnedByApp ViewportFlags = 1 << 2
 )
 
 // MainViewport returns primary/default viewport.


### PR DESCRIPTION
Values in Condition.go do not have the correct type.

Only ConditionAlways has the correct Condition type. The Condition type is defined in the same file.

The other values are all of type int. This means those values must be cast to the Condition type in those places where you would expect them to be used. For example, SetNextWindowPosV()


Same comments for other constants.