### PR TITLE
Expose MouseDrawCursor

### DIFF
--- a/IO.go
+++ b/IO.go
@@ -295,6 +295,15 @@ func (io IO) SetBackendFlags(flags BackendFlags) {
 	C.iggIoSetBackendFlags(io.handle, C.int(flags))
 }
 
+// SetMouseDrawCursor request ImGui to draw a mouse cursor for you (if you are on a platform without a mouse cursor).
+func (io IO) SetMouseDrawCursor(show bool) {
+	var showArg C.IggBool
+	if show {
+		showArg = 1
+	}
+	C.iggIoSetMouseDrawCursor(io.handle, showArg)
+}
+
 // Clipboard describes the access to the text clipboard of the window manager.
 type Clipboard interface {
 	// Text returns the current text from the clipboard, if available.

--- a/wrapper/IO.cpp
+++ b/wrapper/IO.cpp
@@ -200,6 +200,12 @@ void iggIoSetBackendFlags(IggIO handle, int flags)
    io.BackendFlags = flags;
 }
 
+void iggIoSetMouseDrawCursor(IggIO handle, IggBool show)
+{
+   ImGuiIO &io = *reinterpret_cast<ImGuiIO *>(handle);
+   io.MouseDrawCursor = show != 0;
+}
+
 extern "C" void iggIoSetClipboardText(IggIO handle, char *text);
 extern "C" char *iggIoGetClipboardText(IggIO handle);
 

--- a/wrapper/IO.h
+++ b/wrapper/IO.h
@@ -41,6 +41,7 @@ extern void iggIoAddInputCharactersUTF8(IggIO handle, char const *utf8Chars);
 extern void iggIoSetIniFilename(IggIO handle, char const *value);
 extern void iggIoSetConfigFlags(IggIO handle, int flags);
 extern void iggIoSetBackendFlags(IggIO handle, int flags);
+extern void iggIoSetMouseDrawCursor(IggIO handle, IggBool show);
 
 extern void iggIoRegisterClipboardFunctions(IggIO handle);
 extern void iggIoClearClipboardFunctions(IggIO handle);


### PR DESCRIPTION
This allows applications to disable the OS cursor and have imgui draw
custom cursors instead. (There's already some built-in for resizing
and text inputs)


![Screenshot 2021-04-02 at 22 19 09](https://user-images.githubusercontent.com/56919/113451165-b6f01e80-9401-11eb-9376-152a7cee6e53.png)
![Screenshot 2021-04-02 at 22 19 28](https://user-images.githubusercontent.com/56919/113451166-b8214b80-9401-11eb-9354-21412869c797.png)
![Screenshot 2021-04-02 at 22 19 33](https://user-images.githubusercontent.com/56919/113451167-b8214b80-9401-11eb-880e-50975d0f15b1.png)

