### PR TITLE
Added PushClipRect and PopClipRect

### DIFF
--- a/DrawList.go
+++ b/DrawList.go
@@ -231,3 +231,25 @@ func (list DrawList) AddImageV(textureID TextureID, posMin Vec2, posMax Vec2, uv
 	uvMaxArg, _ := uvMax.wrapped()
 	C.iggAddImage(list.handle(), C.IggTextureID(textureID), posMinArg, posMaxArg, uvMinArg, uvMaxArg, C.IggPackedColor(tintCol))
 }
+
+// PushClipRect performs render-level scissoring.
+// It calls PushClipRectV(min, max, false).
+func (list DrawList) PushClipRect(min, max Vec2) {
+	list.PushClipRectV(min, max, false)
+}
+
+// PushClipRectV performs render-level scissoring.
+//
+// This is passed down to your render function but not used for CPU-side coarse
+// clipping. Prefer using higher-level imgui.PushClipRect() to affect logic
+// (hit-testing and widget culling).
+func (list DrawList) PushClipRectV(min, max Vec2, intersectWithCurrentClipRect bool) {
+	minArg, _ := min.wrapped()
+	maxArg, _ := max.wrapped()
+	C.iggPushClipRect(list.handle(), minArg, maxArg, castBool(intersectWithCurrentClipRect))
+}
+
+// PopClipRect removes the current clip rect and returns to the previous one.
+func (list DrawList) PopClipRect() {
+	C.iggPopClipRect(list.handle())
+}

--- a/wrapper/DrawList.cpp
+++ b/wrapper/DrawList.cpp
@@ -122,6 +122,20 @@ void iggAddImage(IggDrawList handle, IggTextureID textureID, IggVec2* pMin, IggV
   list->AddImage(reinterpret_cast<ImTextureID>(textureID), *pMinArg, *pMaxArg, *uvMinArg, *uvMaxArg, col);
 }
 
+void iggPushClipRect(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, IggBool intersectWithCurrentClipRect)
+{
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   Vec2Wrapper minArg(min);
+   Vec2Wrapper maxArg(max);
+   list->PushClipRect(*minArg, *maxArg, intersectWithCurrentClipRect != 0);
+}
+
+void iggPopClipRect(IggDrawList handle)
+{
+   ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+   list->PopClipRect();
+}
+
 IggDrawList iggGetWindowDrawList()
 {
    return static_cast<IggDrawList>(const_cast<ImDrawList *>(ImGui::GetWindowDrawList()));

--- a/wrapper/DrawList.h
+++ b/wrapper/DrawList.h
@@ -24,6 +24,9 @@ extern void iggAddTriangleFilled(IggDrawList handle, IggVec2 *p1, IggVec2 *p2, I
 extern void iggAddText(IggDrawList handle, IggVec2 const *pos, IggPackedColor col, const char *text, int length);
 extern void iggAddImage(IggDrawList handle, IggTextureID textureID, IggVec2* pMin, IggVec2* pMax, IggVec2* uvMin, IggVec2* uvMax, IggPackedColor col);
 
+extern void iggPushClipRect(IggDrawList handle, IggVec2 const *min, IggVec2 const *max, IggBool intersectWithCurrentClipRect);
+extern void iggPopClipRect(IggDrawList handle);
+
 extern IggDrawList iggGetWindowDrawList();
 extern IggDrawList iggGetBackgroundDrawList();
 


### PR DESCRIPTION
Add `PushClipRect(min, max Vec2)`, `PushClipRectV(min, max Vec2, intersectWithCurrentClipRect bool)` and `PopClipRect()` to the DrawList API.