### PR TITLE
Expose VtxOffset to allow backends to render more than 64k vertices

### DIFF
--- a/DrawCommand.go
+++ b/DrawCommand.go
@@ -18,6 +18,23 @@ func (cmd DrawCommand) ElementCount() int {
 	return int(count)
 }
 
+// IndexOffset is the start offset in index buffer.
+// Always equal to sum of ElemCount drawn so far.
+func (cmd DrawCommand) IndexOffset() int {
+	var count C.uint
+	C.iggDrawCommandGetIndexOffset(cmd.handle(), &count)
+	return int(count)
+}
+
+// VertexOffset is the start offset in vertex buffer.
+// ImGuiBackendFlags_RendererHasVtxOffset: false always 0,
+// otherwise may be >0 to support meshes larger than 64K vertices with 16-bit indices.
+func (cmd DrawCommand) VertexOffset() int {
+	var count C.uint
+	C.iggDrawCommandGetVertexOffset(cmd.handle(), &count)
+	return int(count)
+}
+
 // ClipRect defines the clipping rectangle (x1, y1, x2, y2).
 func (cmd DrawCommand) ClipRect() (rect Vec4) {
 	rectArg, rectFin := rect.wrapped()

--- a/IO.go
+++ b/IO.go
@@ -295,6 +295,11 @@ func (io IO) SetBackendFlags(flags BackendFlags) {
 	C.iggIoSetBackendFlags(io.handle, C.int(flags))
 }
 
+// GetBackendFlags gets the current backend flags
+func (io IO) GetBackendFlags() BackendFlags {
+	return BackendFlags(C.iggIoGetBackendFlags(io.handle))
+}
+
 // SetMouseDrawCursor request ImGui to draw a mouse cursor for you (if you are on a platform without a mouse cursor).
 func (io IO) SetMouseDrawCursor(show bool) {
 	C.iggIoSetMouseDrawCursor(io.handle, castBool(show))

--- a/IO.go
+++ b/IO.go
@@ -295,7 +295,7 @@ func (io IO) SetBackendFlags(flags BackendFlags) {
 	C.iggIoSetBackendFlags(io.handle, C.int(flags))
 }
 
-// GetBackendFlags gets the current backend flags
+// GetBackendFlags gets the current backend flags.
 func (io IO) GetBackendFlags() BackendFlags {
 	return BackendFlags(C.iggIoGetBackendFlags(io.handle))
 }

--- a/wrapper/DrawCommand.cpp
+++ b/wrapper/DrawCommand.cpp
@@ -9,6 +9,18 @@ void iggDrawCommandGetElementCount(IggDrawCmd handle, unsigned int *count)
    *count = cmd->ElemCount;
 }
 
+void iggDrawCommandGetIndexOffset(IggDrawCmd handle, unsigned int *count)
+{
+   ImDrawCmd *cmd = reinterpret_cast<ImDrawCmd *>(handle);
+   *count = cmd->IdxOffset;
+}
+
+void iggDrawCommandGetVertexOffset(IggDrawCmd handle, unsigned int *count)
+{
+   ImDrawCmd *cmd = reinterpret_cast<ImDrawCmd *>(handle);
+   *count = cmd->VtxOffset;
+}
+
 void iggDrawCommandGetClipRect(IggDrawCmd handle, IggVec4 *rect)
 {
    ImDrawCmd *cmd = reinterpret_cast<ImDrawCmd *>(handle);

--- a/wrapper/DrawCommand.h
+++ b/wrapper/DrawCommand.h
@@ -7,6 +7,8 @@ extern "C" {
 #endif
 
 extern void iggDrawCommandGetElementCount(IggDrawCmd handle, unsigned int *count);
+extern void iggDrawCommandGetIndexOffset(IggDrawCmd handle, unsigned int *count);
+extern void iggDrawCommandGetVertexOffset(IggDrawCmd handle, unsigned int *count);
 extern void iggDrawCommandGetClipRect(IggDrawCmd handle, IggVec4 *rect);
 extern void iggDrawCommandGetTextureID(IggDrawCmd handle, IggTextureID *id);
 extern IggBool iggDrawCommandHasUserCallback(IggDrawCmd handle);

--- a/wrapper/IO.cpp
+++ b/wrapper/IO.cpp
@@ -200,6 +200,13 @@ void iggIoSetBackendFlags(IggIO handle, int flags)
    io.BackendFlags = flags;
 }
 
+int iggIoGetBackendFlags(IggIO handle)
+{
+   ImGuiIO &io = *reinterpret_cast<ImGuiIO *>(handle);
+   return io.BackendFlags;
+}
+
+
 void iggIoSetMouseDrawCursor(IggIO handle, IggBool show)
 {
    ImGuiIO &io = *reinterpret_cast<ImGuiIO *>(handle);

--- a/wrapper/IO.h
+++ b/wrapper/IO.h
@@ -41,6 +41,7 @@ extern void iggIoAddInputCharactersUTF8(IggIO handle, char const *utf8Chars);
 extern void iggIoSetIniFilename(IggIO handle, char const *value);
 extern void iggIoSetConfigFlags(IggIO handle, int flags);
 extern void iggIoSetBackendFlags(IggIO handle, int flags);
+extern int iggIoGetBackendFlags(IggIO handle);
 extern void iggIoSetMouseDrawCursor(IggIO handle, IggBool show);
 
 extern void iggIoRegisterClipboardFunctions(IggIO handle);


### PR DESCRIPTION
I'll make a companion change to imgui-go-examples that updates the
opengl3 backend

(This is needed as part of my work to support `implot` which can create some huge vertex lists)