### PR TITLE
Add getters for draw data sizes

### DIFF
--- a/DrawData.go
+++ b/DrawData.go
@@ -39,6 +39,40 @@ func (data DrawData) CommandLists() []DrawList {
 	return list
 }
 
+// DisplayPos returns the top-left position of the viewport to render.
+// Use this as the top-left of the orthogonal projection matrix.
+// For the main viewport this is equal to MainViewport().Pos().
+// Usually {0, 0} in a single-viewport application.
+func (data DrawData) DisplayPos() Vec2 {
+	var value Vec2
+	valueArg, valueFin := value.wrapped()
+	C.iggDrawDataDisplayPos(data.handle(), valueArg)
+	valueFin()
+	return value
+}
+
+// DisplaySize returns the size of the viewport to render.
+// For the main viewport this is equal to MainViewport().Size().
+// Usually set by IO.SetDisplaySize().
+func (data DrawData) DisplaySize() Vec2 {
+	var value Vec2
+	valueArg, valueFin := value.wrapped()
+	C.iggDrawDataDisplaySize(data.handle(), valueArg)
+	valueFin()
+	return value
+}
+
+// FrameBufferScale returns the amount of pixels for each unit of DisplaySize().
+// Generally (1,1) on normal display, (2,2) on OSX with Retina display.
+// See also IO.DisplayFrameBufferScale().
+func (data DrawData) FrameBufferScale() Vec2 {
+	var value Vec2
+	valueArg, valueFin := value.wrapped()
+	C.iggDrawDataFrameBufferScale(data.handle(), valueArg)
+	valueFin()
+	return value
+}
+
 // ScaleClipRects is a helper to scale the ClipRect field of each DrawCmd.
 // Use if your final output buffer is at a different scale than ImGui expects,
 // or if there is a difference between your window resolution and framebuffer resolution.

--- a/wrapper/DrawData.cpp
+++ b/wrapper/DrawData.cpp
@@ -23,6 +23,24 @@ void iggDrawDataGetCommandLists(IggDrawData handle, void **handles, int *count)
    *count = drawData->CmdListsCount;
 }
 
+void iggDrawDataDisplayPos(IggDrawData handle, IggVec2 *value)
+{
+   ImDrawData *drawData = reinterpret_cast<ImDrawData *>(handle);
+   exportValue(*value, drawData->DisplayPos);
+}
+
+void iggDrawDataDisplaySize(IggDrawData handle, IggVec2 *value)
+{
+   ImDrawData *drawData = reinterpret_cast<ImDrawData *>(handle);
+   exportValue(*value, drawData->DisplaySize);
+}
+
+void iggDrawDataFrameBufferScale(IggDrawData handle, IggVec2 *value)
+{
+   ImDrawData *drawData = reinterpret_cast<ImDrawData *>(handle);
+   exportValue(*value, drawData->FramebufferScale);
+}
+
 void iggDrawDataScaleClipRects(IggDrawData handle, IggVec2 const *scale)
 {
    ImDrawData *drawData = reinterpret_cast<ImDrawData *>(handle);

--- a/wrapper/DrawData.h
+++ b/wrapper/DrawData.h
@@ -9,6 +9,9 @@ extern "C" {
 extern IggDrawData iggGetDrawData(void);
 extern IggBool iggDrawDataValid(IggDrawData handle);
 extern void iggDrawDataGetCommandLists(IggDrawData handle, void **handles, int *count);
+extern void iggDrawDataDisplayPos(IggDrawData handle, IggVec2 *value);
+extern void iggDrawDataDisplaySize(IggDrawData handle, IggVec2 *value);
+extern void iggDrawDataFrameBufferScale(IggDrawData handle, IggVec2 *value);
 extern void iggDrawDataScaleClipRects(IggDrawData handle, IggVec2 const *scale);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Reference: https://github.com/ocornut/imgui/blob/d9b606672ae145457d12dacdc82b82c6ce9ebd79/imgui.h#L2498

For consistency with the existing `IO.SetDisplayFrameBufferScale()` function, the capitalization of `FrameBuffer` was changed compared to the imgui sources.