### PR TITLE
Add string formatting overloads for Text, LabelText, TreeNode, SetTooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Functions that don't have optional parameters don't come in a verbose variant.
 
 The **Dear ImGui** functions `IO()` and `Style()` have been renamed to be `CurrentIO()` and `CurrentStyle()`.
 This was done because their returned types have the same name, causing a name clash.
-With the `Current` prefix, they also better describe what they return.  
+With the `Current` prefix, they also better describe what they return.
 
 ## API philosophy
 This library does not intend to export all the functions of the wrapped **Dear ImGui**. The following filter applies as a rule of thumb:
 * Functions marked as "obsolete" are not available. (The corresponding C code isn't even compiled - disabled by define)
-* "Shortcut" Functions, which combine language features and/or other **Dear ImGui** functions, are not available. Prime example are the Text*() functions for instance: Text formatting should be done with fmt.Sprintf(), and style formatting with the corresponding Push/Pop functions.
+* "Shortcut" Functions, which combine language features and/or other **Dear ImGui** functions, are not available. There may be exceptions for this if the shortcut exists in Dear ImGui code base (e.g. `ImGui::Text` which does printf style string formatting)
 * Functions that are not needed by InkyBlackness are ignored. This doesn't mean that they can't be in the wrapper, they are simply not a priority. Feel free to propose an implementation or make a pull request, respecting the previous points :)
 
 ## Version philosophy

--- a/Widgets.go
+++ b/Widgets.go
@@ -3,7 +3,10 @@ package imgui
 // #include "wrapper/Widgets.h"
 import "C"
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // Text adds formatted text. See PushTextWrapPosV() or PushStyleColorV() for modifying the output.
 // Without any modified style stack, the text is unformatted.
@@ -14,6 +17,11 @@ func Text(text string) {
 	C.iggTextUnformatted(textArg)
 }
 
+// Textf calls Text(fmt.Sprintf(format, v...)
+func Textf(format string, v ...interface{}) {
+	Text(fmt.Sprintf(format, v...))
+}
+
 // LabelText adds text+label aligned the same way as value+label widgets.
 func LabelText(label, text string) {
 	labelArg, labelFin := wrapString(label)
@@ -21,6 +29,11 @@ func LabelText(label, text string) {
 	textArg, textFin := wrapString(text)
 	defer textFin()
 	C.iggLabelText(labelArg, textArg)
+}
+
+// LabelTextf calls LabelText(label, fmt.Sprintf(format, v...))
+func LabelTextf(label, format string, v ...interface{}) {
+	LabelText(label, fmt.Sprintf(format, v...))
 }
 
 // ButtonV returns true if it is clicked.
@@ -757,6 +770,11 @@ func TreeNode(label string) bool {
 	return TreeNodeV(label, 0)
 }
 
+// TreeNodeF calls TreeNode(fmt.Sprintf(format, v...))
+func TreeNodef(format string, v ...interface{}) bool {
+	return TreeNode(fmt.Sprintf(format, v...))
+}
+
 // TreePop finishes a tree branch. This has to be called for a matching TreeNodeV call returning true.
 func TreePop() {
 	C.iggTreePop()
@@ -936,6 +954,11 @@ func SetTooltip(text string) {
 	textArg, textFin := wrapString(text)
 	defer textFin()
 	C.iggSetTooltip(textArg)
+}
+
+// SetTooltipf calls SetTooltip(fmt.Sprintf(format, v...))
+func SetTooltipf(format string, v ...interface{}) {
+	SetTooltip(fmt.Sprintf(format, v...))
 }
 
 // BeginTooltip begins/appends to a tooltip window. Used to create full-featured tooltip (with any kind of contents).

--- a/Widgets.go
+++ b/Widgets.go
@@ -770,7 +770,7 @@ func TreeNode(label string) bool {
 	return TreeNodeV(label, 0)
 }
 
-// TreeNodeF calls TreeNode(fmt.Sprintf(format, v...)) .
+// TreeNodef calls TreeNode(fmt.Sprintf(format, v...)) .
 func TreeNodef(format string, v ...interface{}) bool {
 	return TreeNode(fmt.Sprintf(format, v...))
 }

--- a/Widgets.go
+++ b/Widgets.go
@@ -17,7 +17,7 @@ func Text(text string) {
 	C.iggTextUnformatted(textArg)
 }
 
-// Textf calls Text(fmt.Sprintf(format, v...)
+// Textf calls Text(fmt.Sprintf(format, v...) .
 func Textf(format string, v ...interface{}) {
 	Text(fmt.Sprintf(format, v...))
 }
@@ -31,7 +31,7 @@ func LabelText(label, text string) {
 	C.iggLabelText(labelArg, textArg)
 }
 
-// LabelTextf calls LabelText(label, fmt.Sprintf(format, v...))
+// LabelTextf calls LabelText(label, fmt.Sprintf(format, v...)) .
 func LabelTextf(label, format string, v ...interface{}) {
 	LabelText(label, fmt.Sprintf(format, v...))
 }
@@ -770,7 +770,7 @@ func TreeNode(label string) bool {
 	return TreeNodeV(label, 0)
 }
 
-// TreeNodeF calls TreeNode(fmt.Sprintf(format, v...))
+// TreeNodeF calls TreeNode(fmt.Sprintf(format, v...)) .
 func TreeNodef(format string, v ...interface{}) bool {
 	return TreeNode(fmt.Sprintf(format, v...))
 }
@@ -956,7 +956,7 @@ func SetTooltip(text string) {
 	C.iggSetTooltip(textArg)
 }
 
-// SetTooltipf calls SetTooltip(fmt.Sprintf(format, v...))
+// SetTooltipf calls SetTooltip(fmt.Sprintf(format, v...)) .
 func SetTooltipf(format string, v ...interface{}) {
 	SetTooltip(fmt.Sprintf(format, v...))
 }


### PR DESCRIPTION
Fixes #168 

I've looked looked for all places which had `va_args` overloads in Dear ImGui. 
I think it's worth to add every such "wrapper" function, because people porting their code from C++ to Go might have easier time adjusting their code as-is. :)